### PR TITLE
Tell tar to use the wildcard instead of looking for a folder called '*'.

### DIFF
--- a/express/bin/rhc-snapshot
+++ b/express/bin/rhc-snapshot
@@ -126,7 +126,7 @@ else
       puts "i.e.: tar -czvf <app_name>.tar.gz ./<app_uuid>/"
       exit 255
     else
-      `tar -tf #{opt['restore']} './*/git'`
+      `tar --wildcards -tf #{opt['restore']} './*/git'`
       include_git = $?.exitstatus == 0
       ssh_cmd = "cat #{opt['restore']} | ssh #{app_uuid}@#{app}-#{namespace}.#{rhc_domain} 'restore#{include_git ? ' INCLUDE_GIT' : ''}'"
       puts "Restoring from snapshot #{opt['restore']}"


### PR DESCRIPTION
When attempting to restore a backup with rhc-snapshot, I got the following message:

tar: Pattern matching characters used in file names  
tar: Use --wildcards to enable pattern matching, or --no-wildcards to suppress this warning
tar: ./*/appname: Not found in archive
tar: Exiting with failure status due to previous errors

On my machine, --no-wildcards is the default, thus not allowing me to continue from this point.  With this change, the restore works as expected.
