### PR TITLE
rhc-port-forward compatibility bug for ruby 1.9

### DIFF
--- a/express/bin/rhc-port-forward
+++ b/express/bin/rhc-port-forward
@@ -86,7 +86,7 @@ end
 
 # mock for windows
 if defined?(UNIXServer) != 'constant' or UNIXServer.class != Class
-  class UNIXServer; end 
+  class UNIXServer; end
 end
 
 app_uuid = user_info['app_info'][app_name]['uuid']
@@ -109,20 +109,20 @@ Net::SSH.start(ssh_host, app_uuid) do |ssh|
   ssh.exec! "rhc-list-ports" do |channel, stream, data|
 
     # data comes from a linux server so it is a one-line string for windows, we need to split \n manually
-    if RHC::Helpers.windows? 
+    if RHC::Helpers.windows?
       data = data.split /\n/
     end
 
     if stream == :stderr
 
-      data.each { |line|
+      data.lines { |line|
         line = line.chomp
 
         if line.downcase =~ /permission denied/
           puts line
           exit 1
         end
-        
+
         if line.index(ip_and_port_simple_regex)
           hosts_and_ports_descriptions << line
         end
@@ -130,7 +130,7 @@ Net::SSH.start(ssh_host, app_uuid) do |ssh|
 
     else
 
-      data.each { |line|
+      data.lines { |line|
         line = line.chomp
 
         if line.downcase =~ /scale/
@@ -149,7 +149,7 @@ Net::SSH.start(ssh_host, app_uuid) do |ssh|
   end
 
   scaled_uuids.each { |scaled_uuid|
-    
+
     puts "Using #{scaled_uuid}@#{ssh_host} (scaled instance)..." if debug
 
     Net::SSH.start(ssh_host, scaled_uuid) do |ssh|
@@ -202,12 +202,12 @@ Net::SSH.start(ssh_host, app_uuid) do |ssh|
       end
       ssh.loop { true }
     end
-  
+
   rescue Interrupt
     puts
     puts "Terminating..."
     exit 0
-    
+
   rescue Exception => e
     puts
     puts e.message if debug


### PR DESCRIPTION
command: `rhc port-forward -a app`
on ruby: `1.9.3-p194`
with: openshift/os-client-tools@7f9b8c485815ec298c401cb65c474e946163f322 or gem: 0.93.18  

After running the above command, you get this doozy:

```
Checking available ports...
express/bin/rhc-port-forward:118:in `block (2 levels) in <main>': undefined method `each' for "mongod -> 127.6.40.1:27017\nnginx -> 127.6.40.1:8080\n":String (NoMethodError)
    … (snipped)
    from express/bin/rhc-port-forward:107:in `<main>'
```

 This is simply because 1.9.x doesn't have the `each` method on strings anymore, it prefers either `lines` (which literally separates lines platform-specifically) or one of the `each_` methods. Luckily the `lines` method exists for both 1.8 and 1.9. Backwards **and** forwards compatibility win - huzzah!
