### PR TITLE
Added a rescue to handle server errors when attempting to create auto-scaling apps

### DIFF
--- a/lib/rhc-common.rb
+++ b/lib/rhc-common.rb
@@ -536,6 +536,9 @@ end
       rescue Rhc::Rest::ValidationException => e
         validation_error_code = (e.code.nil?) ? 406 : e.code
         print_response_err(Struct::FakeResponse.new(e.message, validation_error_code))
+      rescue Rhc::Rest::ServerErrorException => e
+        error_code = (e.code.nil?) ? 500 : e.code
+        print_response_err(Struct::FakeResponse.new(e.message, error_code))
       end
     else
       json_data = generate_json(data)

--- a/spec/rhc/common_spec.rb
+++ b/spec/rhc/common_spec.rb
@@ -1,0 +1,50 @@
+require 'stringio'
+require 'spec_helper'
+require 'rest_spec_helper'
+require 'rhc-common'
+
+# The existence of this file is a stopgap to provide test coverage
+# for a specific bug fix (BZ836882). This test should be migrated
+# to a more appropriate location when rhc-common is refactored out
+# of existence.
+
+include RHC
+RHC.module_eval(%q{def self.print_response_err(message) @test_output = message; exit(1) end})
+RHC.module_eval(%q{def get_test_output() @test_output end})
+
+describe RHC do
+  let(:client_links) { mock_response_links(mock_client_links) }
+  let(:domain_links) { mock_response_links(mock_domain_links('mock_domain')) }
+  let(:user_info) {
+    { 'user_info' => { 'domains' => [ { 'namespace' => 'mock_domain' } ] } }
+  }
+  context "#create_app" do
+    context " creating a scaling app" do
+      before do
+        stub_request(:get, mock_href('broker/rest/api', true)).
+          to_return({ :body   => { :data => client_links }.to_json,
+                      :status => 200
+                    })
+        stub_request(:any, mock_href(client_links['LIST_DOMAINS']['relative'], true)).
+          to_return({ :body   => {
+                        :type => 'domains',
+                        :data =>
+                        [{ :id    => 'mock_domain',
+                           :links => domain_links,
+                         }]
+                      }.to_json,
+                      :status => 200
+                    })
+        stub_request(:any, mock_href(domain_links['ADD_APPLICATION']['relative'], true)).
+          to_raise(Rhc::Rest::ServerErrorException.new("Mock server error"))
+      end
+      it "posts an error message if the Rest API encounters a server error" do
+        lambda{ RHC.create_app( mock_uri, Net::HTTP, user_info,
+                                    'mock_app', 'mock_type', mock_user, mock_pass,
+                                    nil, false, false, false, 'small', true) }.
+          should raise_error(SystemExit)
+        RHC.get_test_output.body.should match(/Mock server error/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change resolves https://bugzilla.redhat.com/show_bug.cgi?id=836882 in the rhc client app.
