### PR TITLE
Bug 839889, Bug 841430 and use health_check_path returned by API

### DIFF
--- a/lib/rhc-common.rb
+++ b/lib/rhc-common.rb
@@ -519,20 +519,12 @@ end
         app_uuid = application.uuid
         result = "Successfully created application: #{app_name}"
 
-        # Since health_check_path is not returned, we need to fudge it for now
-        health_check_path =
-          case app_type
-          when /^php/
-            "health_check.php"
-          when /^perl/
-            "health_check.pl"
-          when /^zend/
-            "health_check.php"
-          else
-            "health"
-          end
+        # health check path now returned by the API
+        health_check_path = application.health_check_path
 
         puts "DEBUG: '#{app_name}' creation returned success." if @mydebug
+      rescue Rhc::Rest::ConnectionException => e
+        print_response_err(Struct::FakeResponse.new(e.message,e.code))
       rescue Rhc::Rest::ResourceAccessException => e
         print_response_err(Struct::FakeResponse.new(e.message,e.code))
       rescue Rhc::Rest::ValidationException => e

--- a/lib/rhc-rest.rb
+++ b/lib/rhc-rest.rb
@@ -60,7 +60,8 @@ module Rhc
       end
     end
 
-    def request(request)
+    def request(request, retries=0)
+      response = nil
       begin
         response = request.execute
         #set cookie
@@ -68,15 +69,20 @@ module Rhc
         if not rh_sso.nil?
           @@headers["cookie"] = "rh_sso=#{rh_sso}"
         end
-        return parse_response(response) unless response.nil? or response.code == 204
-      rescue RestClient::RequestTimeout, RestClient::ServerBrokeConnection, RestClient::SSLCertificateNotVerified => e
-        raise ResourceAccessException.new("Failed to access resource: #{e.message}")
+      rescue RestClient::RequestTimeout, RestClient::ServerBrokeConnection => e
+        # if it is a get request then re-try
+        if retries>0
+          sleep 5*retries
+          return request(request, retries-1)
+        else
+          raise ConnectionException.new("Connection to server timed out or got interrupted: #{e.message}")
+        end
       rescue RestClient::ExceptionWithResponse => e
-      #puts "#{e.response}"
         process_error_response(e.response)
       rescue Exception => e
         raise ResourceAccessException.new("Failed to access resource: #{e.message}")
       end
+      return parse_response(response) unless response.nil? or response.code == 204
     end
 
     def process_error_response(response)

--- a/lib/rhc-rest/exceptions/exceptions.rb
+++ b/lib/rhc-rest/exceptions/exceptions.rb
@@ -66,8 +66,10 @@ module Rhc
     #that authorization has been refused for those credentials. 
     class UnAuthorizedException < Rhc::Rest::ClientErrorException; end
 
-    #I/O Exceptions Connection timeouts, Unreachable host, etc
+    # Unreachable host, SSL Exception
     class ResourceAccessException < Rhc::Rest::BaseException; end
+    #I/O Exceptions Connection timeouts, etc
+    class ConnectionException < Rhc::Rest::BaseException; end
 
   end
 end


### PR DESCRIPTION
changes:

```
rhc-rest returns a ConnectionException in case of request timeout or connection interruption.
Added retries so for GET operations the rhc-rest library retries the request before throwing an exception
updated rhc-common.rb to use health_check_path returned by the API
```
