### PR TITLE
Bug 839889, Bug 841430 and use health_check_path returned by API

### DIFF
--- a/lib/rhc-common.rb
+++ b/lib/rhc-common.rb
@@ -522,21 +522,11 @@ end
         app_uuid = application.uuid
         result = "Successfully created application: #{app_name}"
 
-        # Since health_check_path is not returned, we need to fudge it for now
-        health_check_path =
-          case app_type
-          when /^php/
-            "health_check.php"
-          when /^perl/
-            "health_check.pl"
-          when /^zend/
-            "health_check.php"
-          else
-            "health"
-          end
+        # health check path now returned by the API
+        health_check_path = application.health_check_path
 
         puts "DEBUG: '#{app_name}' creation returned success." if @mydebug
-      rescue Rhc::Rest::ResourceAccessException => e
+      rescue Rhc::Rest::ConnectionException, Rhc::Rest::ResourceAccessException => e
         print_response_err(Struct::FakeResponse.new(e.message,e.code))
       rescue Rhc::Rest::ValidationException => e
         validation_error_code = (e.code.nil?) ? 406 : e.code

--- a/lib/rhc-rest.rb
+++ b/lib/rhc-rest.rb
@@ -71,10 +71,9 @@ module Rhc
           @@headers["cookie"] = "rh_sso=#{rh_sso}"
         end
         return parse_response(response) unless response.nil? or response.code == 204
-      rescue RestClient::RequestTimeout, RestClient::ServerBrokeConnection, RestClient::SSLCertificateNotVerified => e
-        raise ResourceAccessException.new("Failed to access resource: #{e.message}")
+      rescue RestClient::RequestTimeout, RestClient::ServerBrokeConnection => e
+        raise ConnectionException.new("Connection to server timed out or got interrupted: #{e.message}")
       rescue RestClient::ExceptionWithResponse => e
-      #puts "#{e.response}"
         process_error_response(e.response)
       rescue Exception => e
         raise ResourceAccessException.new("Failed to access resource: #{e.message}")

--- a/lib/rhc-rest/exceptions/exceptions.rb
+++ b/lib/rhc-rest/exceptions/exceptions.rb
@@ -66,8 +66,10 @@ module Rhc
     #that authorization has been refused for those credentials. 
     class UnAuthorizedException < Rhc::Rest::ClientErrorException; end
 
-    #I/O Exceptions Connection timeouts, Unreachable host, etc
+    # Unreachable host, SSL Exception
     class ResourceAccessException < Rhc::Rest::BaseException; end
+    #I/O Exceptions Connection timeouts, etc
+    class ConnectionException < Rhc::Rest::BaseException; end
 
   end
 end


### PR DESCRIPTION
Provide a different message for cases where connection between server and client is severed or the request is timed out by client.

Use health check path returned by the API
