### PR TITLE
Use TLSv1 handshake when connecting to the server

### DIFF
--- a/lib/rhc-common.rb
+++ b/lib/rhc-common.rb
@@ -370,6 +370,7 @@ end
     http.read_timeout = @read_timeout
     if url.scheme == "https"
       http.use_ssl = true
+      http.ssl_version = :TLSv1
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
     begin


### PR DESCRIPTION
I've been following the instructions for building your own multi-node PaaS. rhc commands on the broker work just fune, but when trying to connect remotely I got an error about the connection failing due to an SSL error. This sets the SSL protocol to TLSv1, which allows connections without error.
