### PR TITLE
Send `tar …` output to /dev/null

### DIFF
--- a/lib/rhc/targz.rb
+++ b/lib/rhc/targz.rb
@@ -30,7 +30,7 @@ module RHC
           return false
         end
       else
-        `#{TAR_BIN} --wildcards -tf #{filename} '#{search.to_s}' 2>&1 > /dev/null`
+        `#{TAR_BIN} --wildcards -tf #{filename} '#{search.to_s}' 2> /dev/null`
         contains = $?.exitstatus == 0
       end
       contains


### PR DESCRIPTION
When calling "(gnu)tar" via shell, send output to /dev/null, so that when the tar file doesn not contain the file we are looking for, the error message does not seep through to the output.
