### PR TITLE
Further cleanup of targz.rb.

### DIFF
--- a/lib/rhc/targz.rb
+++ b/lib/rhc/targz.rb
@@ -35,6 +35,6 @@ module RHC
       end
     end
 
- end
+  end
 
 end


### PR DESCRIPTION
First, avoid using Object#is_a?
Second, choose the return value more succinctly.
Third, slightly relax the file extension requirement (which is somewhat dubious, IMO) for the file to be examined.
