### PR TITLE
[bug 854152] make sure we don't have newlines in base64 auth encoding

### DIFF
--- a/lib/rhc/rest/client.rb
+++ b/lib/rhc/rest/client.rb
@@ -9,7 +9,10 @@ module RHC
         # use mydebug for legacy reasons
         @mydebug = @mydebug || debug
         logger.debug "Connecting to #{end_point}" if @mydebug
-        credentials = Base64.encode64("#{username}:#{password}")
+
+        # we remove all newlines instead of having the Base64 module handle it
+        # because ruby 1.9 and 1.8 have different APIs for not adding newlines
+        credentials = Base64.encode64("#{username}:#{password}").delete("\n")
         @@headers["Authorization"] = "Basic #{credentials}"
         @@headers["User-Agent"] = RHC::Helpers.user_agent rescue nil
         #first get the API
@@ -19,8 +22,6 @@ module RHC
           response = request.execute
           result = RHC::Json.decode(response)
           @links = request(request)
-        rescue RestClient::ExceptionWithResponse => e
-            logger.error "Failed to get API #{e.response}"
         rescue => e
           raise ResourceAccessException.new("Resource could not be accessed:#{e.message}")
         end

--- a/lib/rhc/rest/client.rb
+++ b/lib/rhc/rest/client.rb
@@ -14,7 +14,7 @@ module RHC
         userpass = "#{username}:#{password}"
         # :nocov: version dependent code
         if RUBY_VERSION.to_f == 1.8
-          credentials = Base64.b64encode(userpass, userpass.length)
+          credentials = Base64.b64encode(userpass, userpass.length).strip
         else
           credentials = Base64.strict_encode64(userpass)
         end

--- a/lib/rhc/rest/client.rb
+++ b/lib/rhc/rest/client.rb
@@ -10,9 +10,15 @@ module RHC
         @mydebug = @mydebug || debug
         logger.debug "Connecting to #{end_point}" if @mydebug
 
-        # we remove all newlines instead of having the Base64 module handle it
-        # because ruby 1.9 and 1.8 have different APIs for not adding newlines
-        credentials = Base64.encode64("#{username}:#{password}").delete("\n")
+        credentials = nil
+        userpass = "#{username}:#{password}"
+        # :nocov: version dependent code
+        if RUBY_VERSION.to_f == 1.8
+          credentials = Base64.b64encode(userpass, userpass.length)
+        else
+          credentials = Base64.strict_encode64(userpass)
+        end
+        # :nocov:
         @@headers["Authorization"] = "Basic #{credentials}"
         @@headers["User-Agent"] = RHC::Helpers.user_agent rescue nil
         #first get the API

--- a/spec/rest_spec_helper.rb
+++ b/spec/rest_spec_helper.rb
@@ -12,10 +12,10 @@ Spec::Matchers.define :have_same_attributes_as do |expected|
 end
 
 # ruby 1.8 does not have strict_encode
-if RUBY_VERSION == 1.8
+if RUBY_VERSION.to_f == 1.8
   module Base64
-    def strict_encode(value)
-      b64encode(value, value.length)
+    def strict_encode64(value)
+      b64encode(value, value.length).strip
     end
   end
 end

--- a/spec/rest_spec_helper.rb
+++ b/spec/rest_spec_helper.rb
@@ -1,12 +1,22 @@
 require 'webmock/rspec'
 require 'rhc/rest'
 require 'rhc/exceptions'
+require 'base64'
 
 Spec::Matchers.define :have_same_attributes_as do |expected|
   match do |actual|
     (actual.instance_variables == expected.instance_variables) &&
       (actual.instance_variables.map { |i| instance_variable_get(i) } ==
        expected.instance_variables.map { |i| instance_variable_get(i) })
+  end
+end
+
+# ruby 1.8 does not have strict_encode
+if RUBY_VERSION == 1.8
+  module Base64
+    def strict_encode(value)
+      b64encode(value, value.length)
+    end
   end
 end
 

--- a/spec/rhc/rest_application_spec.rb
+++ b/spec/rhc/rest_application_spec.rb
@@ -11,7 +11,7 @@ module RHC
     describe Application do
       # make sure auth is set up for the Application object since we are not
       # calling it from RHC::Rest::Client
-      credentials = Base64.encode64("#{mock_user}:#{mock_pass}")
+      credentials = Base64.strict_encode64("#{mock_user}:#{mock_pass}")
       @@headers["Authorization"] = "Basic #{credentials}"
 
       let (:app_links) { mock_response_links(mock_app_links('mock_domain','mock_app')) }

--- a/spec/rhc/rest_application_spec.rb
+++ b/spec/rhc/rest_application_spec.rb
@@ -13,6 +13,7 @@ module RHC
       # calling it from RHC::Rest::Client
       credentials = Base64.strict_encode64("#{mock_user}:#{mock_pass}")
       @@headers["Authorization"] = "Basic #{credentials}"
+      @@headers["User-Agent"] = RHC::Helpers.user_agent
 
       let (:app_links) { mock_response_links(mock_app_links('mock_domain','mock_app')) }
       let (:app_obj) {

--- a/spec/rhc/rest_client_spec.rb
+++ b/spec/rhc/rest_client_spec.rb
@@ -43,7 +43,7 @@ module RHC
         end
 
         it "returns a client object from the required arguments" do
-          credentials = Base64.encode64(mock_user + ":" + mock_pass).delete("\n")
+          credentials = Base64.strict_encode64(mock_user + ":" + mock_pass)
           client      = RHC::Rest::Client.new(mock_href, mock_user, mock_pass)
           @@headers['Authorization'].should == "Basic #{credentials}"
           client.instance_variable_get(:@links).should == client_links

--- a/spec/rhc/rest_client_spec.rb
+++ b/spec/rhc/rest_client_spec.rb
@@ -43,14 +43,19 @@ module RHC
         end
 
         it "returns a client object from the required arguments" do
-          credentials = Base64.encode64(mock_user + ":" + mock_pass)
+          credentials = Base64.encode64(mock_user + ":" + mock_pass).delete("\n")
           client      = RHC::Rest::Client.new(mock_href, mock_user, mock_pass)
           @@headers['Authorization'].should == "Basic #{credentials}"
           client.instance_variable_get(:@links).should == client_links
         end
-        it "logs an error message if the API cannot be connected" do
-          client = MockClient.new(mock_href('api_error'), mock_user, mock_pass)
-          client.logged.should =~ /API Error$/
+        it "does not add newlines to username and password > 60 characters" do
+          username = "a" * 45
+          password = "p" * 45
+          client   = RHC::Rest::Client.new(mock_href, mock_user, mock_pass)
+          @@headers['Authorization'].should_not match("\n")
+        end
+        it "raises an error message if the API cannot be connected" do
+          expect { MockClient.new(mock_href('api_error'), mock_user, mock_pass) }.should raise_error
         end
         it "raises a generic error for any other error condition" do
           lambda{ RHC::Rest::Client.new(mock_href('other_error'), mock_user, mock_pass) }.


### PR DESCRIPTION
Added a new spec test for large username and passwords and fixed a couple of other tests.
