### PR TITLE
use encode64().delete("\n") since b64encode prints to stdout

### DIFF
--- a/lib/rhc/rest/client.rb
+++ b/lib/rhc/rest/client.rb
@@ -14,7 +14,7 @@ module RHC
         userpass = "#{username}:#{password}"
         # :nocov: version dependent code
         if RUBY_VERSION.to_f == 1.8
-          credentials = Base64.b64encode(userpass, userpass.length).strip
+          credentials = Base64.encode64(userpass).delete("\n")
         else
           credentials = Base64.strict_encode64(userpass)
         end

--- a/spec/rest_spec_helper.rb
+++ b/spec/rest_spec_helper.rb
@@ -15,7 +15,7 @@ end
 if RUBY_VERSION.to_f == 1.8
   module Base64
     def strict_encode64(value)
-      b64encode(value, value.length).strip
+      encode64(value).delete("\n")
     end
   end
 end


### PR DESCRIPTION
fixes bug#855234
