### PR TITLE
[Bug #856056] make sure set_terminal is called and disable color for windows

### DIFF
--- a/bin/rhc
+++ b/bin/rhc
@@ -58,6 +58,7 @@ begin
   else
     begin
       require 'rhc/cli'
+      RHC::CLI.set_terminal
       RHC::CLI.start(ARGV)
       retcode = 0
     rescue SystemExit => e

--- a/lib/rhc/cli.rb
+++ b/lib/rhc/cli.rb
@@ -21,11 +21,13 @@ module RHC
 
     def self.set_terminal
       $terminal.wrap_at = HighLine::SystemExtensions.terminal_size.first - 5 rescue 80 if $stdin.tty?
+      # FIXME: ANSI terminals are not default on windows but we may just be
+      #        hitting a bug in highline if windows does support another method.
+      #        This is a safe fix for now but needs more research.
       HighLine::use_color = false if RHC::Helpers.windows?
     end
 
     def self.start(args)
-      set_terminal
       runner = RHC::CommandRunner.new(args)
       Commander::Runner.instance_variable_set :@singleton, runner
 


### PR DESCRIPTION
Windows does not support ANSI terminals by default so disable.

set_terminal seemed like the right place to put this code but it wasn't being called so I call set_terminal at the top of CLI.start.  I'm not sure if this is correct so asking for review
