### PR TITLE
Fix Bug 856876 - Caught unexpected error messages when adding an sshkey with private key

### DIFF
--- a/features/sshkey.feature
+++ b/features/sshkey.feature
@@ -34,6 +34,12 @@ As an OpenShift user, I want to manage SSH keys with 'rhc sshkey' commands.
     Then the command exits with status code 128
   
   @sshkey_add
+  Scenario: a valid private SSH key is added
+    Given the SSH key "key1" does not exist
+    When a new SSH key "features/support/key1" is added as "key1"
+    Then the command exits with status code 128
+  
+  @sshkey_add
   Scenario: SSH key with the same name already exists
     Given the SSH key "key1" already exists
     When a new SSH key "features/support/key2.pub" is added as "key1"

--- a/lib/rhc/commands/sshkey.rb
+++ b/lib/rhc/commands/sshkey.rb
@@ -57,7 +57,7 @@ module RHC::Commands
       # validate the user input before sending it to the server
       begin
         Net::SSH::KeyFactory.load_data_public_key "#{type} #{content}"
-      rescue NotImplementedError, Net::SSH::Exception => e
+      rescue NotImplementedError, OpenSSL::PKey::PKeyError, Net::SSH::Exception => e
         raise ::RHC::KeyDataInvalidException.new("File '#{key}' contains invalid data")
       end
 


### PR DESCRIPTION
Catch OpenSSL::PKey::PKeyError when key validation fails.
