### PR TITLE
BZ855213: Updated rhc cucumber tests

### DIFF
--- a/features/lib/rhc_helper/sshkey.rb
+++ b/features/lib/rhc_helper/sshkey.rb
@@ -1,29 +1,33 @@
 require "rhc/rest"
 
 module RHCHelper
-  
+
   class Sshkey
     extend Runnable
     extend Commandify
-    
+
     class << self
       attr_accessor :sshkey_output, :exitcode
     end
-    
+
     def self.list(*args)
       rhc_sshkey_list args
     end
-    
+
     def self.show(*args)
       rhc_sshkey_show args
     end
-    
+
     def self.add(*args)
       rhc_sshkey_add args
     end
-    
+
     def self.remove(*args)
       rhc_sshkey_remove args
+    end
+
+    def self.keyfile_path(name)
+      File.expand_path(File.join(File.dirname(__FILE__),'..','..','support',name))
     end
   end
 end

--- a/features/sshkey.feature
+++ b/features/sshkey.feature
@@ -2,63 +2,57 @@
 Feature: SSH key Management
 As an OpenShift user, I want to manage SSH keys with 'rhc sshkey' commands.
 
-  @sshkey_list
+  @sshkey_list @key1
   Scenario: SSH key is listed
-    Given the SSH key "key1" already exists
-    When 'rhc sshkey list' is run
+    When the existing keys are listed
     Then the output includes the key information
-  
-  @sshkey_show
+
+  @sshkey_show @key1
   Scenario: SSH key is shown individually
-    Given the SSH key "key1" already exists
-    When 'rhc sshkey show "key1"' is run
+    When the key "key1" is shown
     Then the output includes the key information for "key1"
-  
+
   @sshkey_show
   Scenario: Requested SSH key does not exist
-    Given the SSH key "key2" does not exist
-    When 'rhc sshkey show "key2"' command is run
+    When the key "key2" is shown
     Then the command exits with status code 118
-  
+
   @sshkey_add
   Scenario: SSH key is added successfully
-    Given the SSH key "key1" does not exist
-    When a new SSH key "features/support/key1.pub" is added as "key1"
-    Then the key "key1" should exist
+    When a new SSH key "key1.pub" is added as "key1"
+    And the key "key1" is shown
+    Then the output includes the key information for "key1"
     And the command exits with status code 0
-  
+
   @sshkey_add
   Scenario: invalid SSH key is added
-    Given the SSH key "key1" does not exist
-    When a new SSH key "features/support/key3.pub" is added as "key3"
+    When a new SSH key "key3.pub" is added as "key3"
     Then the command exits with status code 128
-  
+
   @sshkey_add
   Scenario: a valid private SSH key is added
-    Given the SSH key "key1" does not exist
-    When a new SSH key "features/support/key1" is added as "key1"
+    When a new SSH key "key1" is added as "key1"
     Then the command exits with status code 128
-  
-  @sshkey_add
+
+  @sshkey_add @key1
   Scenario: SSH key with the same name already exists
-    Given the SSH key "key1" already exists
-    When a new SSH key "features/support/key2.pub" is added as "key1"
+    When a new SSH key "key2.pub" is added as "key1"
     Then the command exits with status code 128
-  
+
   @sshkey_add
   Scenario: SSH key with the identical content already exists
-    Given an SSH key "key2" with the same content as "key1" exists
-    And the SSH key "key1" does not exist
-    When 'rhc sshkey add "key1" "features/support/key1.pub"' is run
+    Given a new SSH key "key1.pub" is added as "key1"
+    And a new SSH key "key1.pub" is added as "key2"
     Then the command exits with status code 128
   
-  @sshkey_remove
+
+  @sshkey_remove @key1
   Scenario: SSH key is deleted successfully
-    When 'rhc sshkey remove "key1"' is run
-    Then the SSH key "key1" is deleted
-  
+    When the key "key1" is removed
+    And the key "key1" is shown
+    Then the output does not include the key information for "key1"
+
   @sshkey_remove
   Scenario: SSH key requested to be deleted does not exist
-    Given the SSH key "key1" does not exist
-    When 'rhc sshkey remove "key1"' is run
+    When the key "key1" is removed
     Then the command exits with status code 118

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -23,9 +23,9 @@ Given /^an existing (or new )?(.+) (application with.*)$/ do |create,type, embed
   @app = App.find_on_fs(options)
 
   if create && @app.nil?
-    step "a #{type} application is created"
+    When "a #{type} application is created"
     embeds.each do |embed|
-      step "the #{embed} cartridge is added"
+      When "the #{embed} cartridge is added"
     end
   end
 

--- a/features/support/assumptions.rb
+++ b/features/support/assumptions.rb
@@ -1,11 +1,17 @@
 Given 'we have the client tools setup' do
-  step 'the libra client tools'
-  step 'the client tools should be setup if needed'
+  When 'the libra client tools'
+  When 'the client tools should be setup if needed'
 end
 
 Given 'we have an existing domain' do
-  step 'we have the client tools setup'
-  step 'a new domain is needed and created'
+  When 'we have the client tools setup'
+  When 'a new domain is needed and created'
+  begin
+    When 'the key "key1" is shown'
+    Then 'the output includes the key information for "key1"'
+  rescue Spec::Expectations::ExpectationNotMetError
+    Given 'a new SSH key "key1.pub" is added as "key1"'
+  end
 end
 
 Given /^we have a (.*) (.*) cartridge$/ do |status,type|
@@ -20,18 +26,18 @@ Given /^we have a (.*) (.*) cartridge$/ do |status,type|
   #  only try once
   retried = false
   begin
-    step "the #{type} cartridge should be #{status}"
+    When "the #{type} cartridge should be #{status}"
   rescue Spec::Expectations::ExpectationNotMetError
-    step "the #{type} cartridge is #{cmd}"
+    When "the #{type} cartridge is #{cmd}"
     (retried = true && retry) unless retried
   end
 end
 
 Given /^we have a (stopped|running) application$/ do |state|
   begin
-    step "the application should not be accessible"
-    step "the application is started" if state == "running"
+    When "the application should not be accessible"
+    When "the application is started" if state == "running"
   rescue Spec::Expectations::ExpectationNotMetError
-    step "the application is stopped" if state == "stopped"
+    When "the application is stopped" if state == "stopped"
   end
 end

--- a/features/support/before_hooks.rb
+++ b/features/support/before_hooks.rb
@@ -1,14 +1,23 @@
+Before('@sshkey') do
+  Sshkey.remove "key1"
+  Sshkey.remove "key2"
+end
+
+Before('@sshkey','@key1') do
+  Given 'a new SSH key "key1.pub" is added as "key1"'
+end
+
 # Defined the required hooks first so we make sure we have everything we need
 Before('@domain_required') do
-  step 'we have an existing domain'
+  When 'we have an existing domain'
 end
 
 Before('@client_tools_required') do
-  step 'we have the client tools setup'
+  When 'we have the client tools setup'
 end
 
 Before('@single_cartridge','@init') do
-  step 'an existing or new php-5.3 application without an embedded cartridge'
+  When 'an existing or new php-5.3 application without an embedded cartridge'
 end
 
 # These assumptions help to ensure any steps that are run independently have the same state as after the @init step
@@ -19,7 +28,7 @@ end
   :single_cartridge => 'an existing or new php-5.3 application with an embedded mysql-5.1 cartridge',
   :multiple_cartridge => 'an existing or new php-5.3 application with embedded mysql-5.1 and phpmyadmin-3.4 cartridges',
 }.each do |tag,assumption|
-  Before("@#{tag}",'~@init') do
-    step assumption
+    Before("@#{tag}",'~@init') do
+      When assumption
+    end
   end
-end

--- a/features/support/ssh.sh
+++ b/features/support/ssh.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-ssh -o StrictHostKeyChecking=no -- "$@"


### PR DESCRIPTION
Updated RHC cucumber tests to properly ensure the ssh keys are uploaded to an account
Also modifies ~/.ssh/config so they will work for the `@rhc_extended` tests as well if these are run first
