### PR TITLE
Fix for Bug 863962

### DIFF
--- a/lib/rhc/commands/snapshot.rb
+++ b/lib/rhc/commands/snapshot.rb
@@ -62,58 +62,50 @@ module RHC::Commands
 
       if File.exists? filename
 
-        if ! RHC::Helpers.windows? and ! RHC::TarGz.contains filename, './*/' + app
-          raise RHC::SnapshotRestoreException.new "Archive at #{filename} does not contain the target application: ./*/#{app}
-          If you created this archive rather than exported with rhc snapshot save, be sure
-          the directory structure inside the archive starts with ./<app_uuid>/
-          i.e.: tar -czvf <app_name>.tar.gz ./<app_uuid>/"
-        else
+        include_git = RHC::Helpers.windows? ? false : RHC::TarGz.contains(filename, './*/git')
 
-          include_git = RHC::Helpers.windows? ? false : RHC::TarGz.contains(filename, './*/git')
+        ssh_uri = URI.parse(rest_client.find_domain(options.namespace).find_application(app).ssh_url)
 
-          ssh_uri = URI.parse(rest_client.find_domain(options.namespace).find_application(app).ssh_url)
+        ssh_cmd = "cat #{filename} | ssh #{ssh_uri.user}@#{ssh_uri.host} 'restore#{include_git ? ' INCLUDE_GIT' : ''}'"
 
-          ssh_cmd = "cat #{filename} | ssh #{ssh_uri.user}@#{ssh_uri.host} 'restore#{include_git ? ' INCLUDE_GIT' : ''}'"
+        say "Restoring from snapshot #{filename}..."
+        debug ssh_cmd
 
-          say "Restoring from snapshot #{filename}..."
-          debug ssh_cmd
-
-          begin
-            if ! RHC::Helpers.windows?
-              output = Kernel.` ssh_cmd
-              if $?.exitstatus != 0
-                debug output
-                raise RHC::SnapshotRestoreException.new "Error in trying to restore snapshot. You can try to restore manually by running:\n#{ssh_cmd}"
-              end
-            else
-              ssh = Net::SSH.start(ssh_uri.host, ssh_uri.user)
-              ssh.open_channel do |channel|
-                channel.exec("restore#{include_git ? ' INCLUDE_GIT' : ''}") do |ch, success|
-                  channel.on_data do |ch, data|
-                    say data
-                  end
-                  channel.on_extended_data do |ch, type, data|
-                    say data
-                  end
-                  channel.on_close do |ch|
-                    say "Terminating..."
-                  end
-                  File.open(filename, 'rb') do |file|
-                    file.chunk(1024) do |chunk|
-                      channel.send_data chunk
-                    end
-                  end
-                  channel.eof!
-                end
-              end
-              ssh.loop
+        begin
+          if ! RHC::Helpers.windows?
+            output = Kernel.` ssh_cmd
+            if $?.exitstatus != 0
+              debug output
+              raise RHC::SnapshotRestoreException.new "Error in trying to restore snapshot. You can try to restore manually by running:\n#{ssh_cmd}"
             end
-          rescue Timeout::Error, Errno::EADDRNOTAVAIL, Errno::EADDRINUSE, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Net::SSH::AuthenticationFailed => e
-            debug e.backtrace
-            raise RHC::SnapshotRestoreException.new "Error in trying to restore snapshot. You can try to save manually by running:\n#{ssh_cmd}"
+          else
+            ssh = Net::SSH.start(ssh_uri.host, ssh_uri.user)
+            ssh.open_channel do |channel|
+              channel.exec("restore#{include_git ? ' INCLUDE_GIT' : ''}") do |ch, success|
+                channel.on_data do |ch, data|
+                  say data
+                end
+                channel.on_extended_data do |ch, type, data|
+                  say data
+                end
+                channel.on_close do |ch|
+                  say "Terminating..."
+                end
+                File.open(filename, 'rb') do |file|
+                  file.chunk(1024) do |chunk|
+                    channel.send_data chunk
+                  end
+                end
+                channel.eof!
+              end
+            end
+            ssh.loop
           end
-
+        rescue Timeout::Error, Errno::EADDRNOTAVAIL, Errno::EADDRINUSE, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Net::SSH::AuthenticationFailed => e
+          debug e.backtrace
+          raise RHC::SnapshotRestoreException.new "Error in trying to restore snapshot. You can try to save manually by running:\n#{ssh_cmd}"
         end
+
       else
         raise RHC::SnapshotRestoreException.new "Archive not found: #{filename}"
       end


### PR DESCRIPTION
Remove validation for application name during restore. With typeless gears, that would be a very expenisive operation.
