### PR TITLE
Bug 821107 - Allow an unrecognizable SSH key to be uploaded

### DIFF
--- a/spec/rhc/commands/sshkey_spec.rb
+++ b/spec/rhc/commands/sshkey_spec.rb
@@ -58,14 +58,14 @@ describe RHC::Commands::Sshkey do
         end
       end
     end
-    
+
     context "when adding an invalid key" do
       let(:arguments) { %w[sshkey add --noprompt --config test.conf -l test@test.foo -p password foobar id_rsa.pub] }
-    
+
       before :each do
         @rc = MockRestClient.new
       end
-        
+
       it "fails to add the key" do
         FakeFS do
           keys = @rc.sshkeys
@@ -74,7 +74,29 @@ describe RHC::Commands::Sshkey do
             f << 'ssh-rsa AADAQABAAABAQCnCOqK7/mmvZ9AtCAerxjAasJ1rSpfuWT4vNm1+O/Fh0Di3chTWjY9a0M2hEnqkqnVG589L9CqCUeT0kdc3Vgw3JEcacSUr1z7tLr9kO+p/D5lSdQYzDGGRFOZ0H6lc/y8iNxWV1VO/sJvKx6cr5zvKIn8Q6GvhVNOxlai0IOb9FJxLGK95GLpZ+elzh8Tc9giy7KfwheAwhV2JoF9uRltE5JP/CNs7w/E29i1Z+jlueuu8RVotLmhSVNJm91Ey7OCtoI1iBE0Wv/SucFe32Qi08RWTM/MaGGz93KQNOVRGjNkosJjPmP1qU6WGBfliDkJAZXB0b6sEcnx1fbVikwZ'
           end
           expect { run }.should exit_with_code(128)
+          expect { run_output.should match("Name: mockkey") }
           @rc.sshkeys.length.should == num_keys
+        end
+      end
+    end
+
+    context "when adding an invalid key with --confirm" do
+      let(:arguments) { %w[sshkey add --noprompt --confirm --config test.conf -l test@test.foo -p password foobar id_rsa.pub] }
+
+      before :each do
+        @rc = MockRestClient.new
+      end
+
+      it "warns and then adds the key" do
+        FakeFS do
+          keys = @rc.sshkeys
+          num_keys = keys.length
+          File.open('id_rsa.pub', 'w') do |f|
+            f << 'ssh-rsa AADAQABAAABAQCnCOqK7/mmvZ9AtCAerxjAasJ1rSpfuWT4vNm1+O/Fh0Di3chTWjY9a0M2hEnqkqnVG589L9CqCUeT0kdc3Vgw3JEcacSUr1z7tLr9kO+p/D5lSdQYzDGGRFOZ0H6lc/y8iNxWV1VO/sJvKx6cr5zvKIn8Q6GvhVNOxlai0IOb9FJxLGK95GLpZ+elzh8Tc9giy7KfwheAwhV2JoF9uRltE5JP/CNs7w/E29i1Z+jlueuu8RVotLmhSVNJm91Ey7OCtoI1iBE0Wv/SucFe32Qi08RWTM/MaGGz93KQNOVRGjNkosJjPmP1qU6WGBfliDkJAZXB0b6sEcnx1fbVikwZ'
+          end
+          expect { run }.should exit_with_code(0)
+          expect { run_output.should match("key you are uploading is not recognized") }
+          @rc.sshkeys.length.should == num_keys + 1
         end
       end
     end


### PR DESCRIPTION
Users adding a key can specify --confirm to override validation on the client.  The server may still reject the key and the user will get a warning.
