### PR TITLE
Bug 874829 - Client doesn't report a very coherent error when the server is dead.

### DIFF
--- a/lib/rhc/commands/sshkey.rb
+++ b/lib/rhc/commands/sshkey.rb
@@ -13,11 +13,12 @@ module RHC::Commands
     summary 'Display all the SSH keys for the user account'
     syntax ''
     def list
+      keys = rest_client.sshkeys
+
       results do
-        result = rest_client.sshkeys.inject('') do |r, key|
+        result = keys.inject('') do |r, key|
           r += format(key, erb)
         end
-
         say result
       end
 


### PR DESCRIPTION
Also set open_timeout to 4s and fix an ordering error in rhc sshkey list

@brenton - review for on-prem inclusion
