### PR TITLE
Fixes BZ869973

### DIFF
--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -113,6 +113,8 @@ module RHC
     end
 
     def deprecated(msg,short = false)
+      HighLine::use_color = false if windows? # handle deprecated commands that does not start through highline
+
       info = " For porting and testing purposes you may switch this %s to %s by setting the DISABLE_DEPRECATED environment variable to %d.  It is not recommended to do so in a production environment as this option may be removed in future releases."
 
       msg << info unless short


### PR DESCRIPTION
Old deprecated commands don't start through Highline (RHC::CLI) so the terminal will not be set to not use colours on Windows. Doing that in the "deprecated" method which is basically used by those deprecated commands.
