### PR TITLE
Fix for BZ840938

### DIFF
--- a/lib/rhc-common.rb
+++ b/lib/rhc-common.rb
@@ -471,7 +471,8 @@ end
   # Check if host exists
   #
   def self.hostexist?(host)
-      dns = Resolv::DNS.new
+      # Patch for BZ840938 to support Ruby 1.8 on machines without /etc/resolv.conf
+      dns = Resolv::DNS.new((Resolv::DNS::Config.default_config_hash || {}))
       resp = dns.getresources(host, Resolv::DNS::Resource::IN::A)
       return resp.any?
   end


### PR DESCRIPTION
This fixes DNS resolution on machines that do not have an `/etc/resolv.conf`.

This works by explicitly initializing the config instead of relying on the lazy_ initialize method. This is effectively the same change that was made between Ruby 1.8 and Ruby 1.9 in this [commit](https://github.com/ruby/ruby/commit/926fd9a9).

See [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=840938#c8) for a more in depth explanation.
