### PR TITLE
Address BZ868451: Display what we think are superfluous arguments.

### DIFF
--- a/lib/rhc/commands/base.rb
+++ b/lib/rhc/commands/base.rb
@@ -59,7 +59,7 @@ class RHC::Commands::Base
       end
     end
 
-    raise ArgumentError.new("Too many arguments passed in.") unless fill_args.empty?
+    raise ArgumentError.new("Too many arguments passed in: #{fill_args.reverse.join(" ")}") unless fill_args.empty?
 
     arg_slots
   end


### PR DESCRIPTION
Detecting what the user meant as an action may be too difficult.

https://bugzilla.redhat.com/show_bug.cgi?id=868451
