### PR TITLE
BZ874848

### DIFF
--- a/bin/rhc-chk
+++ b/bin/rhc-chk
@@ -526,8 +526,13 @@ class CheckRunner < Test::Unit::UI::Console::TestRunner
   end
 end
 
-Test::Unit::AutoRunner::RUNNERS[:console] = proc do |r|
-  CheckRunner
+# Need to register the default runner differently using the standard test-unit and the gem
+proc{|*r| CheckRunner}.tap do |_proc|
+  if Test::Unit::AutoRunner.respond_to?(:register_runner)
+    Test::Unit::AutoRunner.register_runner(:console, _proc)
+  else
+    Test::Unit::AutoRunner::RUNNERS[:console] = _proc
+  end
 end
 
 ############################


### PR DESCRIPTION
For some reason the way we were loading the custom test runner stopped working. There is a difference between the standard test-unit lib in Ruby 1.8 and the test-unit gem.

This loads the runner properly in both environments.
