### PR TITLE
Fix BZ874416, minor but annoying formatting glitch

### DIFF
--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -324,7 +324,7 @@ public and private keys id_rsa keys.
         section(:bottom => 1) { say "none found" }
         paragraph do
           say "Run 'rhc app create' to create your first application.\n\n"
-          say "Below is a list of the types of application you can create: \n"
+          say "Below is a list of the types of application you can create:"
 
           application_types = @rest_client.find_cartridges :type => "standalone"
           application_types.sort {|a,b| a.name <=> b.name }.each do |cart|


### PR DESCRIPTION
The output should now read:

```
Run 'rhc app create' to create your first application.
Below is a list of the types of application you can create:
    * diy-0.1 - rhc app create <app name> diy-0.1
    * jbossas-7 - rhc app create <app name> jbossas-7
    * jbosseap-6.0 - rhc app create <app name> jbosseap-6.0
    * jbossews-1.0 - rhc app create <app name> jbossews-1.0
⋮
```
