### PR TITLE
Prevent ask_password from stripping whitespace

### DIFF
--- a/lib/rhc-common.rb
+++ b/lib/rhc-common.rb
@@ -965,7 +965,10 @@ def config
 end
 
 def ask_password
-  return ask("Password: ") { |q| q.echo = '*' }
+  return ask("Password: ") { |q|
+    q.echo = '*'
+    q.whitespace = :chomp
+  }
 end
 
 def kfile_not_found


### PR DESCRIPTION
Get HighLine.ask() to process whitespace with :chomp rather than :strip (default) so that leading/trailing whitespace in user-entered password is preserved.
