### PR TITLE
Use Resolv::Hosts to resolve hostnames when dns is not used.

### DIFF
--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -346,7 +346,7 @@ module RHC::Commands
 
         # Now start checking for DNS
         for i in 0..MAX_RETRIES-1
-          found = host_exists?(host)
+          found = host_exists?(host) || hosts_file_contains?(host)
           break if found
 
           say "    retry # #{i+1} - Waiting for DNS: #{host}"

--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -345,5 +345,15 @@ Fingerprint: <%= key.fingerprint %>
       dns.getresources(host, Resolv::DNS::Resource::IN::A).any?
       # :nocov:
     end
+    
+    def hosts_file_contains?(host)
+      # :nocov:
+      resolver = Resolv::Hosts.new
+      begin
+        resolver.getaddress host
+      rescue Resolv::ResolvError
+      end
+      # :nocov:
+    end
   end
 end


### PR DESCRIPTION
This allows tests to circumvent DNS propagation by adding host information to `/etc/hosts`.
