### PR TITLE
BZ884636 - Fixed timeout parsing

### DIFF
--- a/lib/rhc/commands/cartridge.rb
+++ b/lib/rhc/commands/cartridge.rb
@@ -163,11 +163,10 @@ module RHC::Commands
     end
 
     summary "Set the scaling range of a cartridge"
-    syntax "<cartridge> [--timeout timeout] [--namespace namespace] [--app app] [--min min] [--max max]"
+    syntax "<cartridge> [--namespace namespace] [--app app] [--min min] [--max max]"
     argument :cart_type, "The name of the cartridge you are reloading", ["-c", "--cartridge cartridge"]
     option ["-n", "--namespace namespace"], "Namespace of the application the cartridge belongs to", :context => :namespace_context, :required => true
     option ["-a", "--app app"], "Application the cartridge belongs to", :context => :app_context, :required => true
-    option ["--timeout timeout"], "Timeout, in seconds, for the session"
     option ["--min min", Integer], "Minimum scaling value"
     option ["--max max", Integer], "Maximum scaling value"
     def scale(cartridge)
@@ -193,11 +192,10 @@ module RHC::Commands
     end
 
     summary 'View/manipulate storage on a cartridge'
-    syntax '<cartridge> -a app [--show] [--add|--remove|--set amount] [--namespace namespace] [--timeout timeout]'
+    syntax '<cartridge> -a app [--show] [--add|--remove|--set amount] [--namespace namespace]'
     argument :cart_type, "The name of the cartridge", ["-c", "--cartridge cart_type"], :arg_type => :list
     option ["-n", "--namespace namespace"], "Namespace of the application the cartridge belongs to", :context => :namespace_context, :required => true
     option ["-a", "--app app"], "Application the cartridge belongs to", :context => :app_context, :required => true
-    option ["--timeout timeout"], "Timeout, in seconds, for the session"
     option ["--show"], "Show the current base and additional storage capacity"
     option ["--add amount"], "Add the indicated amount to the additional storage capacity"
     option ["--remove amount"], "Remove the indicated amount from the additional storage capacity"

--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -84,6 +84,7 @@ module RHC
     global_option '-d', '--debug', "Turn on debugging"
 
     global_option('--timeout seconds', Integer, 'Set the timeout in seconds for network commands') do |value|
+      abort(color("Timeout must be a positive integer",:red)) unless value > 0
       # FIXME: Refactor so we don't have to use a global var here
       $rest_timeout = value
     end

--- a/lib/rhc/rest.rb
+++ b/lib/rhc/rest.rb
@@ -150,7 +150,7 @@ module RHC
     def new_request(options)
       # user specified timeout takes presidence
       options[:timeout] = $rest_timeout || options[:timeout]
-      options[:open_timeout] ||= 4
+      options[:open_timeout] ||= (options[:timeout] || 4)
 
       RestClient::Request.new options
     end


### PR DESCRIPTION
`timeout` was being set, but `open_timeout` was not. Now, if a `timeout` value is passed, it will also be used for the `open_timeout`.

Also removed `timeout` option from cartridges to prevent a conflict with the global option.

Added check for `timeout` value that it must be a positive integer. Negative timeouts break the RestClient and a timeout of 0 makes no sense.
