### PR TITLE
Removing webmock build require

### DIFF
--- a/client.spec
+++ b/client.spec
@@ -13,7 +13,6 @@ Source0:       rhc-%{version}.tar.gz
 BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: rubygem-rake
 BuildRequires: rubygem-rspec
-BuildRequires: rubygem-webmock
 BuildRequires: rubygem-cucumber
 Requires:      ruby >= 1.8.5
 Requires:      rubygem-parseconfig


### PR DESCRIPTION
It doesn't appear to actually be needed and we want to avoid needless
BuildRequires in Enterprise.
