### PR TITLE
In 'rhc domain', detect '--debug' and finesse args so that 'rhc-chk' can...

### DIFF
--- a/lib/rhc/commands/domain.rb
+++ b/lib/rhc/commands/domain.rb
@@ -57,7 +57,15 @@ module RHC::Commands
       options.__hash__.each do |key, value|
         value = value.to_s
         if value.length > 0 && value.to_s.strip.length == 0; value = "'#{value}'" end
-        args << "--#{key} #{value}"
+        # rhc-chk does not take '--debug true', so we need to treat it especially
+        # A long-term solution is to avoid relying on rhc-chk.
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=887136 and
+        # https://bugzilla.redhat.com/show_bug.cgi?id=887309
+        if key.to_s == 'debug'
+          args << "--#{key}"
+        else
+          args << "--#{key} #{value}"
+        end
       end
 
       Kernel.system("rhc-chk #{args.join(' ')} 2>&1")

--- a/spec/rhc/commands/domain_spec.rb
+++ b/spec/rhc/commands/domain_spec.rb
@@ -237,6 +237,13 @@ describe RHC::Commands::Domain do
         @cmd.length.should == "rhc-chk --noprompt true --config test.conf --rhlogin test@test.foo --password password 2>&1".length
       end
     end
+
+    context '-d is passed' do
+      let(:arguments) { ['domain', 'status', '-d', '--noprompt', '--config', 'test.conf', '-l', 'test@test.foo', '-p',  'password'] }
+      it "runs successfully" do
+        expect { run }.should exit_with_code(0)
+      end
+    end
   end
 
   describe 'help' do


### PR DESCRIPTION
... run in debug mode.

See https://bugzilla.redhat.com/show_bug.cgi?id=887136
