### PR TITLE
Suppress the error message from Highline

### DIFF
--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -191,6 +191,10 @@ public and private keys id_rsa keys.
           key_name =  ask("Provide a name for this key: ") do |q|
             q.default = pubkey_default_name
             q.validate = lambda { |p| RHC::check_key(p) }
+            # Since the validator prints the reason for the validation failure,
+            # suppress the message from Highline.
+            # See https://bugzilla.redhat.com/show_bug.cgi?id=886327
+            q.responses[:not_valid] = ''
           end
         end
       end


### PR DESCRIPTION
The default message contains unsightly object info. Since the validator
λ prints a detailed message, we do not need it.
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=886327
