### PR TITLE
Fixes BZ888100.

### DIFF
--- a/bin/rhc-chk
+++ b/bin/rhc-chk
@@ -31,7 +31,7 @@ class Hash
         v.map {|e| e.deep_cleanse(key) if e.is_a? Hash}
       else
         if k.to_s == key
-          self[k] = "#{key}: length #{v.length} starting with #{v[0..1]}"
+          self[k] = "*" * v.length
         end
       end
     end


### PR DESCRIPTION
Walk the debug data structure and cleanse the value if the key matches 'password'.
