### PR TITLE
[test] snapshot.rb: add require 'rhc/targz'

### DIFF
--- a/lib/rhc/commands/snapshot.rb
+++ b/lib/rhc/commands/snapshot.rb
@@ -1,4 +1,5 @@
 require 'rhc/commands/base'
+require 'rhc/targz'
 
 module RHC::Commands
   class Snapshot < Base


### PR DESCRIPTION
Before this commit, the rhc snapshot restore command could generate an
"uninitialized constant RHC::TarGz (NameError)" error message.  This commit
should resolve that issue.
