### PR TITLE
Support --from-code=<URL> on app create

### DIFF
--- a/lib/rhc/core_ext.rb
+++ b/lib/rhc/core_ext.rb
@@ -12,6 +12,10 @@ class Object
     respond_to?(:empty?) ? empty? : !self
   end
 
+  def presence
+    present? ? self : nil
+  end
+
   # Avoid a conflict if to_json is already defined
   unless Object.new.respond_to? :to_json
     def to_json(options=nil)

--- a/lib/rhc/output_helpers.rb
+++ b/lib/rhc/output_helpers.rb
@@ -43,6 +43,7 @@ module RHC
               :creation_time,
               :gear_info,
               :git_url,
+              :initial_git_url,
               :ssh_string,
               :aliases)
           end

--- a/lib/rhc/rest/application.rb
+++ b/lib/rhc/rest/application.rb
@@ -8,7 +8,7 @@ module RHC
       define_attr :domain_id, :name, :creation_time, :uuid, :aliases,
                   :git_url, :app_url, :gear_profile, :framework,
                   :scalable, :health_check_path, :embedded, :gear_count,
-                  :ssh_url, :building_app, :cartridges
+                  :ssh_url, :building_app, :cartridges, :initial_git_url
       alias_method :domain_name, :domain_id
 
       # Query helper to say consistent with cartridge

--- a/lib/rhc/rest/mock.rb
+++ b/lib/rhc/rest/mock.rb
@@ -427,13 +427,14 @@ module RHC::Rest::Mock
       @applications = nil
     end
 
-    def add_application(name, type=nil, scale=nil, gear_profile='default')
+    def add_application(name, type=nil, scale=nil, gear_profile='default', git_url=nil)
       if type.is_a?(Hash)
         scale = type[:scale]
         gear_profile = type[:gear_profile]
+        git_url = type[:initial_git_url]
         type = Array(type[:cartridges] || type[:cartridge])
       end
-      a = MockRestApplication.new(client, name, type, self, scale, gear_profile)
+      a = MockRestApplication.new(client, name, type, self, scale, gear_profile, git_url)
       builder = @applications.find{ |app| app.cartridges.map(&:name).any?{ |s| s =~ /^jenkins-[\d\.]+$/ } }
       a.building_app = builder.name if builder
       @applications << a
@@ -461,13 +462,14 @@ module RHC::Rest::Mock
       "fakeuuidfortests#{@name}"
     end
 
-    def initialize(client, name, type, domain, scale=nil, gear_profile='default')
+    def initialize(client, name, type, domain, scale=nil, gear_profile='default', initial_git_url=nil)
       super({}, client)
       @name = name
       @domain = domain
       @cartridges = []
       @creation_time = Date.new(2000, 1, 1).strftime('%Y-%m-%dT%H:%M:%S%z')
       @uuid = fakeuuid
+      @initial_git_url = initial_git_url
       @git_url = "git:fake.foo/git/#{@name}.git"
       @app_url = "https://#{@name}-#{@domain.id}.fake.foo/"
       @ssh_url = "ssh://#{@uuid}@127.0.0.1"

--- a/spec/rhc/commands/app_spec.rb
+++ b/spec/rhc/commands/app_spec.rb
@@ -57,6 +57,24 @@ describe RHC::Commands::App do
       let(:arguments) { ['app', 'create', 'app1', 'mock_standalone_cart-1', '--noprompt', '--timeout', '10', '--config', 'test.conf', '-l', 'test@test.foo', '-p',  'password'] }
       it { expect { run }.should exit_with_code(0) }
       it { run_output.should match("Success") }
+      it { run_output.should match("Cartridges: mock_standalone_cart-1\n") }
+    end
+
+    context 'when run with multiple carts' do
+      let(:arguments) { ['app', 'create', 'app1', 'mock_standalone_cart-1', 'mock_cart-1', '--noprompt', '-p',  'password'] }
+      it { expect { run }.should exit_with_code(0) }
+      it { run_output.should match("Success") }
+      it { run_output.should match("Cartridges: mock_standalone_cart-1, mock_cart-1\n") }
+      after{ rest_client.domains.first.applications.first.cartridges.find{ |c| c.name == 'mock_cart-1' }.should be_true }
+    end
+
+    context 'when run with a git url' do
+      let(:arguments) { ['app', 'create', 'app1', 'mock_standalone_cart-1', '--from', 'git://url', '--noprompt', '-p',  'password'] }
+      it { expect { run }.should exit_with_code(0) }
+      it { run_output.should match("Success") }
+      it { run_output.should match("Source Code: git://url\n") }
+      it { run_output.should match("Initial Git URL: git://url\n") }
+      after{ rest_client.domains.first.applications.first.initial_git_url.should == 'git://url' }
     end
 
     context 'when no cartridges are returned' do

--- a/spec/rhc/helpers_spec.rb
+++ b/spec/rhc/helpers_spec.rb
@@ -415,6 +415,14 @@ describe Object do
     specify('empty string') { ''.present?.should be_false }
   end
 
+  context 'presence' do
+    specify('nil') { nil.presence.should be_nil }
+    specify('empty array') { [].presence.should be_nil }
+    specify('array') { [1].presence.should == [1] }
+    specify('string') { 'a'.presence.should == 'a' }
+    specify('empty string') { ''.presence.should be_nil }
+  end
+
   context 'blank?' do
     specify('nil') { nil.blank?.should be_true }
     specify('empty array') { [].blank?.should be_true }

--- a/spec/rhc/rest_spec.rb
+++ b/spec/rhc/rest_spec.rb
@@ -486,6 +486,38 @@ module RHC
             method.should raise_error(RHC::Rest::ValidationException, 'mock error message')
           end
         end
+        context "with multiple JSON messages" do
+          let(:json){ { :messages => [{ :field => 'error', :text => 'mock error message 1' },
+                                       { :field => 'error', :text => 'mock error message 2' }] } }
+          it "raises a validation error with concatenated messages" do
+            method.should raise_error(RHC::Rest::ValidationException, "The operation did not complete successfully, but the server returned additional information:\n* mock error message 1\n* mock error message 2")
+          end
+        end
+        context "with multiple errors" do
+          let(:json){ { :messages => [
+                          { :severity => 'error', :field => 'error', :text => 'mock 1' },
+                          { :severity => 'error', :text => 'mock 2' },
+                        ] } }
+          it "raises a validation error with concatenated messages" do
+            method.should raise_error(RHC::Rest::ValidationException, "The server reported multiple errors:\n* mock 1\n* mock 2")
+          end
+        end
+        context "with multiple messages and one error" do
+          let(:json){ { :messages => [
+                          { :field => 'error', :text => 'mock 1' },
+                          { :text => 'mock 2' },
+                          { :severity => 'error', :text => 'mock 3' },
+                        ] } }
+          it "raises a validation error with concatenated messages" do
+            method.should raise_error(RHC::Rest::ValidationException, "mock 3")
+          end
+        end
+        context "with an empty JSON response" do
+          let(:json){ {} }
+          it "raises a validation error" do
+            method.should raise_error(RHC::Rest::ServerErrorException)
+          end
+        end
       end
 
       context "with a 422 response" do
@@ -505,7 +537,7 @@ module RHC
         context "with an empty JSON response" do
           let(:json){ {} }
           it "raises a validation error" do
-            method.should raise_error(RHC::Rest::ValidationException, 'Not valid')
+            method.should raise_error(RHC::Rest::ServerErrorException)
           end
         end
 
@@ -513,7 +545,26 @@ module RHC
           let(:json){ { :messages => [{ :field => 'error', :text => 'mock error message 1' },
                                        { :field => 'error', :text => 'mock error message 2' }] } }
           it "raises a validation error with concatenated messages" do
-            method.should raise_error(RHC::Rest::ValidationException, 'mock error message 1 mock error message 2')
+            method.should raise_error(RHC::Rest::ValidationException, "The operation did not complete successfully, but the server returned additional information:\n* mock error message 1\n* mock error message 2")
+          end
+        end
+        context "with multiple errors" do
+          let(:json){ { :messages => [
+                          { :severity => 'error', :field => 'error', :text => 'mock 1' },
+                          { :severity => 'error', :text => 'mock 2' },
+                        ] } }
+          it "raises a validation error with concatenated messages" do
+            method.should raise_error(RHC::Rest::ValidationException, "The server reported multiple errors:\n* mock 1\n* mock 2")
+          end
+        end
+        context "with multiple messages and one error" do
+          let(:json){ { :messages => [
+                          { :field => 'error', :text => 'mock 1' },
+                          { :text => 'mock 2' },
+                          { :severity => 'error', :text => 'mock 3' },
+                        ] } }
+          it "raises a validation error with concatenated messages" do
+            method.should raise_error(RHC::Rest::ValidationException, "mock 3")
           end
         end
       end
@@ -570,7 +621,7 @@ module RHC
         context "with a formatted JSON response" do
           let(:json){ { :messages => [{ :severity => 'error', :text => 'mock error message' }] } }
           it "raises a resource access error" do
-            method.should raise_error(RHC::Rest::ServerErrorException, 'Server returned an unexpected error code: 999')
+            method.should raise_error(RHC::Rest::ServerErrorException, 'mock error message')
           end
         end
       end


### PR DESCRIPTION
Add support for the --from-code=<URL> parameter on application create. Show a
default message if the broker returns a message with no text.

[merge]
