### PR TITLE
Bug 903071: 'rhc setup' can show unexpected error message

### DIFF
--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -416,7 +416,7 @@ module RHC
           ssh = Net::SSH.start(app.host, app.uuid, :timeout => 60)
           return true
         rescue => e
-          report_result(ssh, "An SSH connection could not be established to #{app.host}. Your SSH configuration may not be correct, or the application may not be responding. #{e.message}", false)
+          report_result(ssh, "An SSH connection could not be established to #{app.host}. Your SSH configuration may not be correct, or the application may not be responding. #{e.message} (#{e.class})", false)
           return false
         ensure
           ssh.close if ssh


### PR DESCRIPTION
Indicate what exception is seen when SSH connection fails, so the
message is more meaningful.
