### PR TITLE
Fixed spec tests for checking colors

### DIFF
--- a/spec/rhc/helpers_spec.rb
+++ b/spec/rhc/helpers_spec.rb
@@ -45,22 +45,40 @@ describe RHC::Helpers do
 
   it("should decode json"){ subject.decode_json("{\"a\" : 1}").should == {'a' => 1} }
 
-  it("should output green on success") do
-    capture{ subject.success 'this is green' }.should == "\e[32mthis is green\e[0m\n"
-  end
-  it("should output yellow on warn") do
-    capture{ subject.success 'this is yellow' }.should == "\e[32mthis is yellow\e[0m\n"
-  end
-  it("should return true on success"){ subject.success('anything').should be_true }
-  it("should return true on success"){ subject.warn('anything').should be_true }
-
-  it("should draw a table") do
-    subject.table([[10,2], [3,40]]) do |i|
-      i.map(&:to_s)
-    end.should == ['10 2','3  40']
+  shared_examples_for "colorized output" do
+    it("should be colorized") do
+      message = "this is #{_color}"
+      output = capture{ subject.send(method,message) }
+      output.should be_colorized(message,_color)
+    end
+    it("should return true"){ subject.send(method,'anything').should be_true }
   end
 
-  it("should output a table") do 
+  context "success output" do
+    let(:_color){ :green }
+    let(:method){ :success }
+    it_should_behave_like "colorized output"
+  end
+
+  context "warn output" do
+    let(:_color){ :yellow }
+    let(:method){ :warn }
+    it_should_behave_like "colorized output"
+  end
+
+  context "info output" do
+    let(:_color){ :cyan }
+    let(:method){ :info }
+    it_should_behave_like "colorized output"
+  end
+
+  context "error output" do
+    let(:_color){ :red }
+    let(:method){ :error }
+    it_should_behave_like "colorized output"
+  end
+
+  it("should output a table") do
     subject.send(:display_no_info, 'test').should == ['This test has no information to show']
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -329,6 +329,48 @@ module CommanderInvocationMatchers
   end  
 end
 
+module ColorMatchers
+  COLORS = {
+    :green => 32,
+    :yellow => 33,
+    :cyan => 36,
+    :red => 31,
+    :clear => 0
+  }
+
+  Spec::Matchers.define :be_colorized do |msg,color|
+    match do |actual|
+      actual == colorized_message(msg,color)
+    end
+
+    failure_message_for_should do |actual|
+      failure_message(actual,msg,color)
+    end
+
+    failure_message_for_should_not do |actual|
+      failure_message(actual,msg,color)
+    end
+
+    def failure_message(actual,msg,color)
+      "expected: #{colorized_message(msg,color).inspect}\n" +
+      "     got: #{actual.inspect}"
+    end
+
+    def ansi_code(color)
+      "\e[#{ColorMatchers::COLORS[color]}m"
+    end
+
+    def colorized_message(msg,color)
+      [
+        ansi_code(color),
+        msg,
+        ansi_code(:clear),
+        "\n"
+      ].join('')
+    end
+  end
+end
+
 def mac?
   RbConfig::CONFIG['host_os'] =~ /^darwin/
 end
@@ -336,6 +378,7 @@ end
 Spec::Runner.configure do |config|
   config.include(ExitCodeMatchers)
   config.include(CommanderInvocationMatchers)
+  config.include(ColorMatchers)
   config.include(ClassSpecHelpers)
 end
 


### PR DESCRIPTION
The current `helpers_spec` was not correct. It should never have actually worked since it was checking the color yellow against the ANSI code for green.
