### PR TITLE
rhc_extended: Fixed find_application in rhc_helper

### DIFF
--- a/features/lib/rhc_helper/app.rb
+++ b/features/lib/rhc_helper/app.rb
@@ -105,7 +105,7 @@ module RHCHelper
 
     # Get a REST client to verify the application is on the server
     def is_created?
-      new_client.domains[0].find_application(name)
+      new_client.find_application($namespace,name)
       true
     rescue RHC::Rest::ApplicationNotFoundException
       false


### PR DESCRIPTION
This was causing the extended tests to fail after we moved find_application
from `domain` to `client`.
