### PR TITLE
Bug 915255 - Track auth preference in the config

### DIFF
--- a/lib/rhc/commands.rb
+++ b/lib/rhc/commands.rb
@@ -40,6 +40,8 @@ module Commander
             if sw = opts.send(:search, :long, key.to_s.gsub(/_/, '-'))
               _, cb, val = sw.send(:conv_arg, nil, value) {|*exc| raise(*exc) }
               cb.call(val) if cb
+            else
+              proxy_options << [key, value]
             end
           end
         end

--- a/lib/rhc/commands/setup.rb
+++ b/lib/rhc/commands/setup.rb
@@ -22,11 +22,11 @@ module RHC::Commands
       to .openshift/express.conf).
 
       If the server supports authorization tokens, you may pass the 
-      --use-token option to instruct the wizard to generate a key for you.
+      --create-token option to instruct the wizard to generate a key for you.
       DESC
     option ["--server NAME"], "Hostname of an OpenShift server", :context => :server_context, :required => true
     option ['--clean'], "Ignore any saved configuration options"
-    option ['--use-token'], "Create an authorization token for this server"
+    option ['--[no-]create-token'], "Create an authorization token for this server"
     def run
       raise OptionParser::InvalidOption, "Setup can not be run with the --noprompt option" if options.noprompt
       RHC::RerunWizard.new(config, options).run ?  0 : 1

--- a/lib/rhc/config.rb
+++ b/lib/rhc/config.rb
@@ -52,6 +52,8 @@ module RHC
       :server =>      ['libra_server', nil, 'The OpenShift server to connect to'],
       :rhlogin =>     ['default_rhlogin', nil, 'Your OpenShift login name'],
       :password =>    nil,
+      :use_authorization_tokens =>
+                      [nil, :boolean, 'If true, the server will attempt to create and use authorization tokens to connect to the server'],
       :timeout =>     [nil, :integer, 'The default timeout for network operations'],
       :insecure =>    [nil, :boolean, "If true, certificate errors will be ignored.\nWARNING: This may allow others to eavesdrop on your communication with OpenShift."],
       :ssl_version => [nil, nil, 'The SSL protocol version to use when connecting to this server'],
@@ -133,7 +135,14 @@ module RHC
           opts = Array(opts)
           value = self[opts[0] || name.to_s]
           if value
-            value = value unless value.blank?
+            value = case opts[1]
+                    when :integer
+                      Integer(value)
+                    when :boolean
+                      !!(value =~ /^\s*(y|yes|1|t|true)\s*$/i)
+                    else
+                      value unless value.blank?
+                    end
             h[name] = value unless value.nil?
           end
           h

--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -158,12 +158,11 @@ module RHC
 
       self.user = rest_client.user
 
-      if rest_client.supports_sessions? && !options.token
-        paragraph do 
+      if rest_client.supports_sessions? && !options.token && options.create_token != false
+        paragraph do
           info "OpenShift can create and store a token on disk which allows to you to access the server without using your password. The key is stored in your home directory and should be kept secret.  You can delete the key at any time by running 'rhc logout'."
-          if options.use_token or agree "Generate a token now? (yes|no) "
+          if options.create_token or agree "Generate a token now? (yes|no) "
             say "Generating an authorization token for this client ... "
-
             token = rest_client.new_session
             options.token = token.token
             self.auth(true).save(token.token)
@@ -190,6 +189,7 @@ module RHC
         changed = Commander::Command::Options.new(options)
         changed.rhlogin = username
         changed.password = nil
+        changed.use_authorization_tokens = options.create_token != false && !changed.token.nil?
 
         FileUtils.mkdir_p File.dirname(config.path)
         config.save!(changed)

--- a/spec/rhc/commands/setup_spec.rb
+++ b/spec/rhc/commands/setup_spec.rb
@@ -39,6 +39,18 @@ describe RHC::Commands::Setup do
 
   it{ command_for('setup').options.server.should == 'openshift.redhat.com' }
   it{ command_for('setup', '--server', 'foo.com').options.server.should == 'foo.com' }
+  it{ command_for('setup', '--no-create-token').options.create_token.should == false }
+  it{ command_for('setup', '--create-token').options.create_token.should == true }
+
+  context "when config has use_authorization_tokens=false" do
+    let!(:config){ base_config{ |c, d| d.add('use_authorization_tokens', 'false') } }
+    it{ command_for('setup').options.use_authorization_tokens.should == false }
+  end
+  context "when config has use_authorization_tokens=true" do
+    let!(:config){ base_config{ |c, d| d.add('use_authorization_tokens', 'true') } }
+    it{ command_for('setup').options.use_authorization_tokens.should == true }
+  end
+
 =begin  context 'when libra_server is set' do
     before{ ENV.should_receive(:[]).any_number_of_times.with('LIBRA_SERVER').and_return('bar.com') }
     it{ command_for('setup').config['libra_server'].should == 'bar.com' }

--- a/spec/rhc/config_spec.rb
+++ b/spec/rhc/config_spec.rb
@@ -48,12 +48,12 @@ describe RHC::Config do
 
     context "with an non true value for insecure" do
       let(:values){ {'insecure' => 'untruth'} }
-      its(:to_options){ should == {:insecure => 'untruth'} }
+      its(:to_options){ should == {:insecure => false} }
     end
 
     context "with an invalid timeout" do
       let(:values){ {'timeout' => 'a'} }
-      its(:to_options){ should == {:timeout => 'a'} }
+      it{ expect{ subject.to_options }.to raise_error(ArgumentError) }
     end
 
     context "with standard values" do
@@ -66,9 +66,10 @@ describe RHC::Config do
           'ssl_client_cert_file' => 'file1',
           'ssl_ca_file' => 'file2',
           'timeout' => '1',
+          'use_authorization_tokens' => 'true',
         }
       end
-      its(:to_options){ should == {:insecure => 'true', :timeout => '1', :ssl_ca_file => 'file2', :ssl_client_cert_file => 'file1', :rhlogin => 'user', :password => 'pass', :server => 'test.com'} }
+      its(:to_options){ should == {:insecure => true, :timeout => 1, :ssl_ca_file => 'file2', :ssl_client_cert_file => 'file1', :rhlogin => 'user', :password => 'pass', :server => 'test.com', :use_authorization_tokens => true} }
     end
   end
 

--- a/spec/wizard_spec_helper.rb
+++ b/spec/wizard_spec_helper.rb
@@ -37,6 +37,7 @@ module WizardStepsHelper
     RHC::Vendor::ParseConfig.new(current_config_path).tap do |cp|
       cp["default_rhlogin"].should == username
       cp["libra_server"].should == mock_uri
+      cp["use_authorization_tokens"].should == 'false'
     end
   end
 


### PR DESCRIPTION
During 'rhc setup', the user's choice to create an auth token is relevant to
later interactions.  If a user declines tokens then later interactions should
not recreate a token on disk, only prompt the user to login with their
password.  This commit adds 'use_authorization_tokens' to the config and is a
remembered value based on 3 states:

  1) did the user pass --no-create-token to the setup command?
 2) did a token get generated when the user hit 'yes'
 3) did the user pass a token to setup via --token?

The value is stored and remembered for future reference when a token expires
