### PR TITLE
Bug 917514 - 'authorization delete' should require at least one token

### DIFF
--- a/lib/rhc/commands/authorization.rb
+++ b/lib/rhc/commands/authorization.rb
@@ -55,6 +55,7 @@ module RHC::Commands
     end
 
     summary "Delete one or more authorization tokens"
+    syntax "<token_or_id> [...<token_or_id>]"
     description <<-DESC
       Delete one or more of the authorization tokens associated with 
       your account. After deletion, any clients using the token will
@@ -62,6 +63,7 @@ module RHC::Commands
       DESC
     argument :auth_token, "The token you wish to delete", ['--auth-token TOKEN'], :arg_type => :list
     def delete(tokens)
+      raise ArgumentError, "You must specify one or more tokens to delete" if tokens.blank?
       say "Deleting authorization ... "
       tokens.each{ |token| rest_client.delete_authorization(token) }
       success "done"

--- a/spec/rhc/commands/authorization_spec.rb
+++ b/spec/rhc/commands/authorization_spec.rb
@@ -56,6 +56,12 @@ describe RHC::Commands::Authorization do
       after{ a_request(:delete, mock_href('broker/rest/user/authorizations/bar', true)).should have_been_made }
     end
 
+    context "without a token in the command line" do
+      let(:arguments) { ['authorization', 'delete'] }
+      it('should display success') { run_output.should =~ /You must specify one or more tokens to delete/ }
+      it{ expect{ run }.should exit_with_code(1) }
+    end
+
     expect_an_unsupported_message
   end
 


### PR DESCRIPTION
[merge]
