### PR TITLE
Bug 917721 - Don't let exceptions get raised from fingerprint tests

### DIFF
--- a/lib/rhc/ssh_helpers.rb
+++ b/lib/rhc/ssh_helpers.rb
@@ -117,10 +117,13 @@ module RHC
       Net::SSH::KeyFactory.load_public_key(key).fingerprint
     rescue NoMethodError, NotImplementedError => e
       ssh_keygen_fallback key
-      return nil
+      nil
     rescue OpenSSL::PKey::PKeyError, Net::SSH::Exception => e
       error e.message
-      return nil
+      nil
+    rescue => e
+      error e.message
+      nil
     end
 
     def fingerprint_for_default_key

--- a/spec/rhc/helpers_spec.rb
+++ b/spec/rhc/helpers_spec.rb
@@ -358,8 +358,14 @@ describe RHC::Helpers do
       subject.should_receive(:error).with('An error')
       subject.fingerprint_for_local_key('1').should be_nil
     end
+
+    it "should catch exceptions from fingerprint failures" do
+      Net::SSH::KeyFactory.should_receive(:load_public_key).with('1').and_raise(StandardError.new("An error"))
+      subject.should_receive(:error).with('An error')
+      subject.fingerprint_for_local_key('1').should be_nil
+    end
   end
-  
+
   context "Resolv helper" do
     let(:resolver) { Object.new }
     let(:existent_host) { 'real_host' }


### PR DESCRIPTION
Any fingerprint failures should be treated as a missing key (Errno::ENOENT,
Errno::EACCESS)
