### PR TITLE
Bug 917457

### DIFF
--- a/lib/rhc/commands/port_forward.rb
+++ b/lib/rhc/commands/port_forward.rb
@@ -130,8 +130,8 @@ module RHC::Commands
                     debug args.inspect
                     ssh.forward.local(*args)
                     fs.bound = true
-                  rescue Errno::EADDRINUSE
-                    debug "trying local port #{fs.port_from}"
+                  rescue Errno::EADDRINUSE, Errno::EACCES => e
+                    warn "#{e} while forwarding port #{fs.port_from}. Trying local port #{fs.port_from+1}"
                     fs.port_from += 1
                   rescue Timeout::Error, Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, Net::SSH::AuthenticationFailed => e
                     given_up = true


### PR DESCRIPTION
When a local port is already bound by another process, we see
Errno::EACCES. Rescue this and try the next port.
