### PR TITLE
Fix Bug 920059

### DIFF
--- a/lib/rhc/ssh_helpers.rb
+++ b/lib/rhc/ssh_helpers.rb
@@ -122,7 +122,7 @@ module RHC
       error e.message
       nil
     rescue => e
-      error e.message
+      debug e.message
       nil
     end
 

--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -245,7 +245,7 @@ module RHC
         key_fingerprint = fingerprint_for_default_key
         unless key_fingerprint
           paragraph do
-            say "Your ssh public key at #{system_path(RHC::Config.ssh_pub_key_file_path)} is invalid or unreadable. "\
+            warn "Your ssh public key at #{system_path(RHC::Config.ssh_pub_key_file_path)} is invalid or unreadable. "\
                 "Setup can not continue until you manually remove or fix your "\
                 "public and private keys id_rsa keys."
           end

--- a/spec/rhc/helpers_spec.rb
+++ b/spec/rhc/helpers_spec.rb
@@ -369,7 +369,6 @@ describe RHC::Helpers do
 
     it "should catch exceptions from fingerprint failures" do
       Net::SSH::KeyFactory.should_receive(:load_public_key).with('1').and_raise(StandardError.new("An error"))
-      subject.should_receive(:error).with('An error')
       subject.fingerprint_for_local_key('1').should be_nil
     end
   end


### PR DESCRIPTION
- When the public key does not exist, put the error message for debugging, not to STDERR.
- Instead, warn the user when the public key does not exist--only once.
- Includes a corresponding change to the spec, since there is no output to STDERR.
