### PR TITLE
Bug 927425 - The use_authorization_tokens flag should be strict

### DIFF
--- a/lib/rhc/commands.rb
+++ b/lib/rhc/commands.rb
@@ -232,7 +232,7 @@ module RHC
         Commander::Runner.instance.options.each do |opt|
           if opt[:context]
             arg = Commander::Runner.switch_to_sym(opt[:switches].last)
-            options[arg] ||= lambda{ cmd.send(opt[:context]) }
+            options.__hash__[arg] ||= lambda{ cmd.send(opt[:context]) }
           end
         end
 

--- a/lib/rhc/commands/account.rb
+++ b/lib/rhc/commands/account.rb
@@ -45,11 +45,11 @@ module RHC::Commands
         rescue RHC::Rest::AuthorizationsNotSupported
           info "not supported"
         end
-      elsif options.token
+      elsif token_for_user
         options.noprompt = true
         say "Ending session on server ... "
         begin
-          rest_client.delete_authorization(options.token)
+          rest_client.delete_authorization(token_for_user)
           success "deleted"
         rescue RHC::Rest::AuthorizationsNotSupported
           info "not supported"

--- a/lib/rhc/commands/authorization.rb
+++ b/lib/rhc/commands/authorization.rb
@@ -12,7 +12,7 @@ module RHC::Commands
       remembering what is available.
       DESC
     def run
-      rest_client.authorizations.each{ |auth| paragraph{ display_authorization(auth, options.token) } } or info "No authorizations"
+      rest_client.authorizations.each{ |auth| paragraph{ display_authorization(auth, token_for_user) } } or info "No authorizations"
 
       0
     end

--- a/lib/rhc/commands/base.rb
+++ b/lib/rhc/commands/base.rb
@@ -31,7 +31,7 @@ class RHC::Commands::Base
     def rest_client(opts={})
       @rest_client ||= begin
           auth = RHC::Auth::Basic.new(options)
-          auth = RHC::Auth::Token.new(options, auth, token_store)
+          auth = RHC::Auth::Token.new(options, auth, token_store) if (options.use_authorization_tokens || options.token) && !(options.rhlogin && options.password)
           client_from_options(:auth => auth)
         end
     end

--- a/lib/rhc/context_helper.rb
+++ b/lib/rhc/context_helper.rb
@@ -12,10 +12,6 @@ module RHC
       ENV['LIBRA_SERVER'] || (!options.clean && config['libra_server']) || "openshift.redhat.com"
     end
 
-    def token_context
-      token_store.get(options.rhlogin, options.server) if options.rhlogin
-    end
-
     def app_context
       debug "Getting app context"
 

--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -100,7 +100,7 @@ module RHC
 
     global_option '-l', '--rhlogin LOGIN', "OpenShift login"
     global_option '-p', '--password PASSWORD', "OpenShift password"
-    global_option '--token TOKEN', "An authorization token for accessing your account.", :context => :token_context
+    global_option '--token TOKEN', "An authorization token for accessing your account."
 
     global_option '-d', '--debug', "Turn on debugging", :hide => true
 
@@ -153,6 +153,10 @@ module RHC
       uri = to_uri((options.server rescue nil) || ENV['LIBRA_SERVER'] || "openshift.redhat.com")
       uri.path = '/broker/rest/api' if uri.path.blank? || uri.path == '/'
       uri
+    end
+    
+    def token_for_user
+      options.token or (token_store.get(options.rhlogin, options.server) if options.rhlogin)
     end
 
     def client_from_options(opts)

--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -99,7 +99,7 @@ module RHC
       end
 
       def username
-        auth.username if auth.respond_to?(:username)
+        options.rhlogin || (auth.username if auth.respond_to?(:username))
       end
 
       def print_dot
@@ -129,7 +129,8 @@ module RHC
     end
 
     def login_stage
-      if options.token
+      if token_for_user
+        options.token = token_for_user
         say "Using an existing token for #{options.rhlogin} to login to #{openshift_server}"
       elsif options.rhlogin
         say "Using #{options.rhlogin} to login to #{openshift_server}"
@@ -161,6 +162,7 @@ module RHC
       end
 
       self.user = rest_client.user
+      options.rhlogin = self.user.login unless username
 
       if rest_client.supports_sessions? && !options.token && options.create_token != false
         paragraph do

--- a/spec/rhc/commands/account_spec.rb
+++ b/spec/rhc/commands/account_spec.rb
@@ -42,7 +42,7 @@ describe RHC::Commands::Account do
   describe '#logout' do
     let(:arguments) { ['account', 'logout'] }
     let(:username) { 'foo' }
-    let(:password) { 'pass' }
+    let(:password) { nil }
     let(:supports_auth) { false }
     let(:server) { mock_uri }
     let!(:token_store) { RHC::Auth::TokenStore.new(Dir.mktmpdir) }


### PR DESCRIPTION
Currently stored tokens are used if use_authorization_tokens is nil or false,
or if the user passes --rhlogin and --password.  In both of these cases, the
token should be ignored.

Removed token context helper and replaced it with a helper method
"token_for_user" which is called in the commands as needed.  Also,
RHC::Auth::Token is not used unless use_authorization_tokens is true or
--token is passed, AND a user/password isn't provided.
