### PR TITLE
Bug 952047 - SSH key doesn't detect duplicate because name is changed

### DIFF
--- a/lib/rhc/highline_extensions.rb
+++ b/lib/rhc/highline_extensions.rb
@@ -236,7 +236,7 @@ class HighLine::Header < Struct.new(:text, :width, :indent, :color)
               if w > width
                 rows.concat(section.textwrap_ansi(width))
               else
-                rows << section
+                rows << section.dup
                 chars += w
               end
             else

--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -305,7 +305,7 @@ module RHC
 
       type, content, comment = ssh_key_triple_for_default_key
 
-      if !ssh_keys.empty? && ssh_keys.any? { |k| k.name == key_name }
+      if ssh_keys.present? && ssh_keys.any? { |k| k.name == key_name }
         clear_ssh_keys_cache
         paragraph do
           say "Key with the name '#{key_name}' already exists. Updating ... "


### PR DESCRIPTION
key.name is being passed to a formatting function which is appending a value
to it.  Prevent strings from being mutated by formatting.
