### PR TITLE
Aliases should not be lazily loaded in some circumstances

### DIFF
--- a/lib/rhc/rest/application.rb
+++ b/lib/rhc/rest/application.rb
@@ -106,10 +106,15 @@ module RHC
 
       def aliases
         debug "Getting all aliases for application #{name}"
-        if (client.api_version_negotiated >= 1.4)
-          rest_method "LIST_ALIASES"
-        else
-          attributes['aliases']
+        @aliases ||= begin
+          aliases = attributes['aliases']
+          if aliases.nil? or not aliases.is_a?(Array)
+            supports?('LIST_ALIASES') ? rest_method("LIST_ALIASES") : []
+          else
+            aliases.map do |a| 
+              Alias.new(a.is_a?(String) ? {'id' => a} : a, client)
+            end
+          end
         end
       end
 

--- a/lib/rhc/rest/base.rb
+++ b/lib/rhc/rest/base.rb
@@ -35,7 +35,7 @@ module RHC
       end
 
       def supports?(sym)
-        links.has_key?(sym.to_s) || links.has_key?(sym.to_s.upcase)
+        !!(links[sym.to_s] || links[sym.to_s.upcase])
       end
 
       protected

--- a/lib/rhc/rest/client.rb
+++ b/lib/rhc/rest/client.rb
@@ -260,7 +260,7 @@ module RHC
             auth = options[:auth] || self.auth
             response = nil
 
-            debug "Request #{args[0].to_s.upcase} #{args[1]}" if debug?
+            debug "Request #{args[0].to_s.upcase} #{args[1]}#{"?#{args[2].map{|a| a.join('=')}.join(' ')}" if args[2] && args[0] == 'GET'}" if debug?
             time = Benchmark.realtime{ response = client.request(*(args << true)) }
             debug "   code %s %4i ms" % [response.status, (time*1000).to_i] if debug? && response
 

--- a/lib/rhc/rest/mock.rb
+++ b/lib/rhc/rest/mock.rb
@@ -414,6 +414,20 @@ module RHC::Rest::Mock
       }
     end
 
+    def mock_alias_response(count=1)
+      aliases = count.times.inject([]) do |arr, i|
+         arr << {:id  => "www.alias#{i}.com"}
+      end
+
+      return {
+        :body   => {
+          :type => count == 1 ? 'alias' : 'aliases',
+          :data => aliases
+        }.to_json,
+        :status => 200
+      }
+    end
+    
     def mock_gear_groups_response()
       groups = [{}]
       type  = 'gear_groups'


### PR DESCRIPTION
Aliases are being lazily executed on app list view, even though they don't
have to be.  Clean up aliases retrieval to be based on capability, rather than
version.
