### PR TITLE
Bug 959144 - Respect use_authorization_tokens=false in rhc setup

### DIFF
--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -163,7 +163,7 @@ module RHC
     end
 
     def token_for_user
-      options.token or (token_store.get(options.rhlogin, options.server) if options.rhlogin)
+      options.token or (token_store.get(options.rhlogin, options.server) if options.rhlogin && options.use_authorization_tokens)
     end
 
     def client_from_options(opts)

--- a/spec/rhc/auth_spec.rb
+++ b/spec/rhc/auth_spec.rb
@@ -422,6 +422,8 @@ describe RHC::Auth::TokenStore do
     before{ subject.put('foo', 'bar', 'token') }
     it("can be retrieved"){ subject.get('foo', 'bar').should == 'token' }
   end
+
+  it("should handle missing files"){ subject.get('foo', 'other').should be_nil }
   it("should put a file on disk"){ expect{ subject.put('test', 'server', 'value') }.to change{ Dir.entries(dir).length }.by(1) }
 
   describe "#clear" do

--- a/spec/rhc/command_spec.rb
+++ b/spec/rhc/command_spec.rb
@@ -306,6 +306,7 @@ describe RHC::Commands::Base do
 
         context "when tokens are not allowed" do
           it("calls the server") { rest_client.send(:auth).is_a? RHC::Auth::Basic }
+          it("does not have a token set") { command_for(*arguments).send(:token_for_user).should be_nil }
         end
 
         context "when tokens are allowed" do


### PR DESCRIPTION
If the config disables use_authorization_tokens, don't automatically pull from
the token store for rhc setup.  Continue to prompt to enable tokens.

@fabianofranz review please
