### PR TITLE
RHC should test server for presence of downloadable carts

### DIFF
--- a/lib/rhc/rest.rb
+++ b/lib/rhc/rest.rb
@@ -113,6 +113,8 @@ module RHC
 
     class MultipleCartridgeCreationNotSupported < Exception; end
 
+    class DownloadingCartridgesNotSupported < Exception; end
+
     class InitialGitUrlNotSupported < Exception; end
 
     class SslCertificatesNotSupported < Exception; end

--- a/lib/rhc/rest/application.rb
+++ b/lib/rhc/rest/application.rb
@@ -24,15 +24,22 @@ module RHC
       def add_cartridge(cart, options={})
         debug "Adding cartridge #{name}"
         clear_attribute :cartridges
-        rest_method(
-          "ADD_CARTRIDGE",
+        cart = 
           if cart.is_a? String 
             {:name => cart}
           elsif cart.respond_to? :[]
             cart
           else
             cart.url ? {:url => cart.url} : {:name => cart.name}
-          end,
+          end
+
+        if cart.respond_to?(:[]) and cart[:url] and !has_param?('ADD_CARTRIDGE', 'url')
+          raise RHC::Rest::DownloadingCartridgesNotSupported, "The server does not support downloading cartridges."
+        end
+
+        rest_method(
+          "ADD_CARTRIDGE",
+          cart,
           options
         )
       end

--- a/lib/rhc/rest/base.rb
+++ b/lib/rhc/rest/base.rb
@@ -17,7 +17,7 @@ module RHC
       end
 
       def rest_method(link_name, payload={}, options={})
-        link = links[link_name.to_s]
+        link = link(link_name)
         raise "No link defined for #{link_name}" unless link
         url = link['href']
         url = url.gsub(/:\w+/) { |s| options[:params][s] } if options[:params]
@@ -35,11 +35,21 @@ module RHC
       end
 
       def supports?(sym)
-        !!(links[sym.to_s] || links[sym.to_s.upcase])
+        !!link(sym)
+      end
+
+      def has_param?(sym, name)
+        if l = link(sym)
+          (l['required_params'] || []).any?{ |p| p['name'] == name} or (l['optional_params'] || []).any?{ |p| p['name'] == name}
+        end
       end
 
       protected
         attr_reader :client
+
+        def link(sym)
+          (links[sym.to_s] || links[sym.to_s.upcase])
+        end
 
         def debug(msg, obj=nil)
           client.debug("#{msg}#{obj ? " #{obj}" : ''}") if client && client.debug?

--- a/lib/rhc/rest/domain.rb
+++ b/lib/rhc/rest/domain.rb
@@ -22,6 +22,11 @@ module RHC
               cart.url ? {:url => cart.url} : cart.name
             end
           end.compact.uniq
+
+        if cartridges.any?{ |c| c.is_a?(Hash) and c[:url] } and !has_param?('ADD_APPLICATION', 'cartridges[][url]')
+          raise RHC::Rest::DownloadingCartridgesNotSupported, "The server does not support downloading cartridges."
+        end
+
         if client.api_version_negotiated >= 1.3
           payload[:cartridges] = cartridges
         else
@@ -29,7 +34,7 @@ module RHC
           payload[:cartridge] = cartridges.first
         end
 
-        if client.api_version_negotiated < 1.3 && payload[:initial_git_url]
+        if payload[:initial_git_url] and !has_param?('ADD_APPLICATION', 'initial_git_url')
           raise RHC::Rest::InitialGitUrlNotSupported, "The server does not support creating applications from a source repository."
         end
 

--- a/lib/rhc/rest/mock.rb
+++ b/lib/rhc/rest/mock.rb
@@ -161,14 +161,14 @@ module RHC::Rest::Mock
     def stub_no_domains
       stub_api_request(:get, 'broker/rest/domains', mock_user_auth).to_return(empty_domains)
     end
-    def stub_one_domain(name)
+    def stub_one_domain(name, optional_params=nil)
       stub_api_request(:get, 'broker/rest/domains', mock_user_auth).
         to_return({
           :body => {
             :type => 'domains',
             :data => [{:id => name, :links => mock_response_links([
               ['LIST_APPLICATIONS', "broker/rest/domains/#{name}/applications", 'get'],
-              ['ADD_APPLICATION', "broker/rest/domains/#{name}/applications", 'post'],
+              ['ADD_APPLICATION', "broker/rest/domains/#{name}/applications", 'post', ({:optional_params => optional_params} if optional_params)],
             ])}],
           }.to_json
         })
@@ -313,16 +313,11 @@ module RHC::Rest::Mock
       "https://#{uri_string}/#{relative}"
     end
 
-    # This formats link lists for JSONification
     def mock_response_links(links)
       link_set = {}
       links.each do |link|
-        operation = link[0]
-        href      = link[1]
-        method    = link[2]
-        # Note that the 'relative' key/value pair below is a convenience for testing;
-        # this is not used by the API classes.
-        link_set[operation] = { 'href' => mock_href(href), 'method' => method, 'relative' => href }
+        options   = link[3] || {}
+        link_set[link[0]] = { 'href' => mock_href(link[1]), 'method' => link[2], 'relative' => link[1]}.merge(options)
       end
       link_set
     end

--- a/spec/rhc/rest_application_spec.rb
+++ b/spec/rhc/rest_application_spec.rb
@@ -75,7 +75,12 @@ module RHC
 
         context "with a URL cart" do
           before{ stub_api_request(:any, app_links['ADD_CARTRIDGE']['relative']).with(:body => {:url => 'http://foo.com'}.to_json).to_return(mock_cartridge_response(1, true)) }
+          it "raises without a param" do
+            app_obj.should_receive(:has_param?).with('ADD_CARTRIDGE','url').and_return(false)
+            expect{ app_obj.add_cartridge({:url => 'http://foo.com'}) }.to raise_error(RHC::Rest::DownloadingCartridgesNotSupported)
+          end
           it "accepts a hash" do
+            app_obj.should_receive(:has_param?).with('ADD_CARTRIDGE','url').and_return(true)
             cart = app_obj.add_cartridge({:url => 'http://foo.com'})
             cart.should be_an_instance_of RHC::Rest::Cartridge
             cart.name.should == 'mock_cart_0'
@@ -86,6 +91,7 @@ module RHC
             cart.only_in_existing?.should be_false
           end
           it "accepts an object" do
+            app_obj.should_receive(:has_param?).with('ADD_CARTRIDGE','url').and_return(true)
             cart = app_obj.add_cartridge(stub(:url => 'http://foo.com'))
             cart.should be_an_instance_of RHC::Rest::Cartridge
             cart.name.should == 'mock_cart_0'

--- a/spec/rhc/rest_spec.rb
+++ b/spec/rhc/rest_spec.rb
@@ -44,13 +44,14 @@ describe RHC::Rest::Domain do
     it{ domain.add_application('foo', :cartridges => ['bar']).should be_true }
     it{ expect{ domain.add_application('foo', :cartridges => ['bar', 'other']) }.to raise_error(RHC::Rest::MultipleCartridgeCreationNotSupported) }
     it{ expect{ domain.add_application('foo', :initial_git_url => 'a_url') }.to raise_error(RHC::Rest::InitialGitUrlNotSupported) }
+    it{ expect{ domain.add_application('foo', :cartridges => [{:url => 'a_url'}]) }.to raise_error(RHC::Rest::DownloadingCartridgesNotSupported) }
     it{ domain.add_application('foo', :cartridges => 'bar').should be_true }
     it{ domain.add_application('foo', :cartridge => 'bar').should be_true }
     it{ domain.add_application('foo', :cartridge => ['bar']).should be_true }
   end
-  context "against a server newer than 1.3" do
+  context "against a server that supports initial git urls and downloaded carts" do
     let(:cartridges){ ['bar'] }
-    before{ stub_api; stub_one_domain('bar') }
+    before{ stub_api; stub_one_domain('bar', [{:name => 'initial_git_url'},{:name => 'cartridges[][url]'}]) }
     before do 
       stub_api_request(:post, 'broker/rest/domains/bar/applications', false).
         with(:body => {:name => 'foo', :cartridges => cartridges}.to_json).


### PR DESCRIPTION
Support for initial_git_url and downloadable cartridges should be tested
against the presence of an optional parameter on the link relation.

Depends on https://github.com/openshift/origin-server/pull/2481
