### PR TITLE
Fedora 19 fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,8 @@ gem 'simplecov', :require => false, :group => :test
 if Gem::Specification.respond_to?(:find_all_by_name) and not Gem::Specification::find_all_by_name('bigdecimal').empty?
   gem 'bigdecimal', :require => false, :group => :test
 end
+
+# Fedora 19 splits psych out into its own gem.
+if Gem::Specification.respond_to?(:find_all_by_name) and not Gem::Specification::find_all_by_name('psych').empty?
+  gem 'psych'
+end

--- a/features/lib/rhc_helper/app.rb
+++ b/features/lib/rhc_helper/app.rb
@@ -117,20 +117,20 @@ module RHCHelper
     end
 
     def get_index_file
-      case @type
-        when "php-5.3","php-5.4" then "php/index.php"
-        when "ruby-1.8" then "config.ru"
-        when "python-2.6" then "wsgi/application"
-        when "perl-5.10" then "perl/index.pl"
-        when "jbossas-7" then "src/main/webapp/index.html"
-        when "jbosseap-6.0" then "src/main/webapp/index.html"
-        when "nodejs-0.6" then "index.html"
+      case @type.split("-").first
+        when "php" then "php/index.php"
+        when "ruby" then "config.ru"
+        when "python" then "wsgi/application"
+        when "perl" then "perl/index.pl"
+        when "jbossas" then "src/main/webapp/index.html"
+        when "jbosseap" then "src/main/webapp/index.html"
+        when "nodejs" then "index.html"
       end
     end
 
     def get_mysql_file
-      case @type
-        when "php-5.3","php-5.4" then File.expand_path("../misc/php/db_test.php", File.expand_path(File.dirname(__FILE__)))
+      case @type.split("-").first
+        when "php" then File.expand_path("../misc/php/db_test.php", File.expand_path(File.dirname(__FILE__)))
       end
     end
   end

--- a/features/support/before_hooks.rb
+++ b/features/support/before_hooks.rb
@@ -45,7 +45,7 @@ Before('@cartridge_storage_user_required') do
   $namespace = nil
 
   if !$cleaned_storage
-    clean_applications($username)
+    clean_applications($username, true)
     $cleaned_storage = true
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,7 +8,15 @@ rescue
   exit 1
 end
 
-$target_os = ENV['RHC_TARGET'] || (File.exist?("/etc/fedora-release") ? "Fedora" : "RHEL")
+$target_os = ENV['RHC_TARGET']
+if $target_os.nil?
+  if File.exist?("/etc/fedora-release")
+    version = File.open("/etc/fedora-release").read.match(/[\w ]*release ([\d]+) [.]*/)[1]
+    $target_os = "fedora-#{version}"
+  else
+    $target_os = "rhel"
+  end
+end
 
 require 'rhc/coverage_helper'
 SimpleCov.at_exit{ SimpleCov.result.format! } if defined? SimpleCov
@@ -82,7 +90,6 @@ if ENV['REGISTER_USER']
   command = $user_register_script_format % [$username,$password]
   if Object.const_defined?('Bundler')
     Bundler::with_clean_env do
-      system "gem install activeresource bundler parseconfig --no-ri --no-rdoc"
       system command
     end
   else

--- a/features/support/platform_support.rb
+++ b/features/support/platform_support.rb
@@ -1,4 +1,4 @@
-if $target_os == 'Fedora'
+if $target_os == 'fedora-18'
   CARTRIDGE_MAP = {
     "php"         => { type: "php-5.4", name: "PHP 5.4" },
     "mysql"       => { type: "mysql-5.1", name: "MySQL Database 5.1" },
@@ -7,6 +7,16 @@ if $target_os == 'Fedora'
     "postgresql"  => { type: "postgresql-9.2", name: "PostgreSQL Database 9.2" },
     "cron"        => { type: "cron-1.4", name: "Cron 1.4" },
     "haproxy"     => { type: "haproxy-1.4", name: "" }
+  }
+elsif $target_os == 'fedora-19'
+  CARTRIDGE_MAP = {
+      "php"         => { type: "php-5.5", name: "PHP 5.5" },
+      "mysql"       => { type: "mariadb-5.5", name: "MariaDB 5.5" },
+      "phpmyadmin"  => { type: "phpmyadmin-3.5", name: "phpMyAdmin 3.5" },
+      "mongodb"     => { type: "mongodb-2.2", name: "MongoDB NoSQL Database 2.2" },
+      "postgresql"  => { type: "postgresql-9.2", name: "PostgreSQL Database 9.2" },
+      "cron"        => { type: "cron-1.4", name: "Cron 1.4" },
+      "haproxy"     => { type: "haproxy-1.4", name: "" }
   }
 else
   CARTRIDGE_MAP = {

--- a/rhc.gemspec
+++ b/rhc.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency      'highline',     '~> 1.6.11'
   s.add_runtime_dependency      'httpclient',   '>= 2.2'
   s.add_runtime_dependency      'open4'
-  s.add_development_dependency  'rake',         '>= 0.8.7', '<= 0.9.2.2'
+  s.add_development_dependency  'rake',         '>= 0.8.7'
   s.add_development_dependency  'webmock',      '>= 1.8'
   s.add_development_dependency  'rspec',        '>= 2.8.0'
   s.add_development_dependency  'fakefs',       '>= 0.4'


### PR DESCRIPTION
Updating RHC tests to work with F19 cartridge versions.
Add psych as optional gem dependency used only on F19 systems
