### PR TITLE
Prevent ask_password from stripping whitespace (Take 2)

### DIFF
--- a/lib/rhc/auth/basic.rb
+++ b/lib/rhc/auth/basic.rb
@@ -49,7 +49,10 @@ module RHC::Auth
         @username = ask("Login to #{openshift_server}: ") unless @no_interactive
       end
       def ask_password
-        @password = ask("Password: ") { |q| q.echo = '*' } unless @no_interactive
+        @password = ask("Password: ") { |q|
+          q.echo = '*'
+          q.whitespace = :chomp
+        } unless @no_interactive
       end
 
       def username?


### PR DESCRIPTION
Get `HighLine.ask()` to process whitespace with `:chomp` rather than `:strip` (default) so that leading/trailing whitespace in user-entered password is preserved.

It was previous fixed in `lib/rhc-common.rb` (now obsolete) in commit a4dd33f717877a2d1731e9c48f1a2abac4234a30 (2012-11-30), and appeared since `rhc-1.2.3-1`.
However, due to a code restructuring which began a day before, starting with commit 0422025c9c4ab487a7b256dfcb8f97eeaf0f7cab (2012-11-29), the fix was not carried over to `lib/rhc/auth.rb` and later `lib/rhc/auth/basic.rb` (commit 5c2d37364912ed717cdbcd3c4be69affa26733a6, 2012-12-12), hence this new patch.

Thanks in advance!
