### PR TITLE
Bug 976682 - Check for web carts was too aggressive

### DIFF
--- a/lib/rhc/cartridge_helpers.rb
+++ b/lib/rhc/cartridge_helpers.rb
@@ -57,9 +57,7 @@ module RHC
           next cart unless cart.is_a? Array
           name = cart.instance_variable_get(:@for)
           matching = cart.select{ |c| not c.only_in_existing? }
-          if matching.empty?
-            raise RHC::MultipleCartridgesException, "You must select only a single web cartridge. '#{name}' matches web cartridges."
-          elsif matching.size == 1
+          if matching.size == 1
             use_cart(matching.first, name)
           else
             matching.instance_variable_set(:@for, name)
@@ -73,9 +71,7 @@ module RHC
           next cart unless cart.is_a? Array
           name = cart.instance_variable_get(:@for)
           matching = cart.select{ |c| not c.only_in_new? }
-          if matching.empty?
-            raise RHC::MultipleCartridgesException, "You must select only a single web cartridge. '#{name}' matches web cartridges."
-          elsif matching.size == 1
+          if matching.size == 1
             use_cart(matching.first, name)
           else
             matching.instance_variable_set(:@for, name)

--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -373,7 +373,7 @@ module RHC::Commands
           end
           if selected_web
             carts.map! &other_carts_only
-          elsif possible_web
+          elsif possible_web && ambiguous.length == 1
             carts.map! &web_carts_only
           end
         }

--- a/lib/rhc/rest/mock.rb
+++ b/lib/rhc/rest/mock.rb
@@ -502,6 +502,8 @@ module RHC::Rest::Mock
        MockRestCartridge.new(self, "mock_cart-2", "embedded"),
        MockRestCartridge.new(self, "unique_mock_cart-1", "embedded"),
        MockRestCartridge.new(self, "jenkins-client-1.4", "embedded"),
+       MockRestCartridge.new(self, "embcart-1", "embedded"),
+       MockRestCartridge.new(self, "embcart-2", "embedded"),
        premium_embedded
       ]
     end

--- a/spec/rhc/commands/app_spec.rb
+++ b/spec/rhc/commands/app_spec.rb
@@ -233,9 +233,7 @@ describe RHC::Commands::App do
   end
 
   describe 'cart matching behavior' do
-    before(:each) do
-      domain = rest_client.add_domain("mockdomain")
-    end
+    before{ rest_client.add_domain("mockdomain") }
 
     context 'multiple web matches' do
       let(:arguments) { ['app', 'create', 'app1', 'mock_standalone_cart', '--trace', '--noprompt'] }
@@ -250,8 +248,8 @@ describe RHC::Commands::App do
       it('picks the non web cart') { run_output.should match('Using unique_mock_cart-1') }
     end
     context 'when I pick very ambiguous carts' do
-      let(:arguments) { ['app', 'create', 'app1', 'mock', '--noprompt'] }
-      it('shows only web carts') { run_output.should_not match('unique_mock_cart-1') }
+      let(:arguments) { ['app', 'create', 'app1', 'mock', 'embcart-', '--noprompt'] }
+      it('shows only web carts') { run_output.should match("There are multiple cartridges matching 'mock'") }
     end
     context 'when I pick only embedded carts' do
       let(:arguments) { ['app', 'create', 'app1', 'mock_cart', '--trace', '--noprompt'] }
@@ -263,7 +261,7 @@ describe RHC::Commands::App do
     end
     context 'when I pick multiple standalone carts' do
       let(:arguments) { ['app', 'create', 'app1', 'unique_standalone', 'mock_standalone_cart', '--trace', '--noprompt'] }
-      it { expect { run }.to raise_error(RHC::MultipleCartridgesException, /You must select only a single web cart/) }
+      it { expect { run }.to raise_error(RHC::MultipleCartridgesException, /There are multiple cartridges matching 'mock_standalone_cart'/) }
     end
     context 'when I pick a custom URL cart' do
       let(:arguments) { ['app', 'create', 'app1', 'http://foo.com', '--trace', '--noprompt'] }
@@ -271,9 +269,9 @@ describe RHC::Commands::App do
       it('lists the cart using the short_name') { run_output.should match(%r(Cartridges:\s+http://foo.com$)) }
     end    
     context 'when I pick a custom URL cart and a web cart' do
-      let(:arguments) { ['app', 'create', 'app1', 'http://foo.com', 'unique_standalone', '--trace', '--noprompt'] }
+      let(:arguments) { ['app', 'create', 'app1', 'http://foo.com', 'embcart-1', '--trace', '--noprompt'] }
       it('tells me about custom carts') { run_output.should match("The cartridge 'http://foo.com' will be downloaded") }
-      it('lists the carts using the short_name') { run_output.should match(%r(Cartridges:\s+http://foo.com, mock_unique_standalone_cart-1$)) }
+      it('lists the carts using the short_name') { run_output.should match(%r(Cartridges:\s+http://foo.com, embcart-1$)) }
     end    
   end
 

--- a/spec/rhc/helpers_spec.rb
+++ b/spec/rhc/helpers_spec.rb
@@ -428,10 +428,6 @@ describe AllRhcHelpers do
       end
     end
 
-    describe '#web_carts_only' do
-      it { expect{ subject.send(:web_carts_only).call([]) }.to raise_error(RHC::MultipleCartridgesException, /You must select only a single web/) }
-    end
-
     describe '#match_cart' do
       context 'with a nil cart' do
         let(:cart){ OpenStruct.new(:name => nil, :description => nil, :tags => nil) }


### PR DESCRIPTION
The logic to figure out which web cart you mean was unnecessary - users need
to resolve multiple ambiguous cart specs by themselves.

@liggitt review please
