### PR TITLE
If the number of columns is zero, do not wrap.

### DIFF
--- a/lib/rhc/cli.rb
+++ b/lib/rhc/cli.rb
@@ -15,6 +15,7 @@ module RHC
 
     def self.set_terminal
       $terminal.wrap_at = HighLine::SystemExtensions.terminal_size.first rescue 80 if $stdin.tty?
+      $terminal.wrap_at = nil if $terminal.wrap_at == 0
       #$terminal.page_at = :auto if $stdin.tty? and $stdout.tty?
       # FIXME: ANSI terminals are not default on windows but we may just be
       #        hitting a bug in highline if windows does support another method.


### PR DESCRIPTION
Sometimes HighLine might return non-nil yet zero value. You can reproduce by

<pre>
# stty columns 0
# rhc cartridges
</pre>


Addressing

<pre>
/usr/lib/ruby/gems/1.8/gems/rhc-1.10.1/lib/rhc/core_ext.rb:100:in `textwrap_ansi': can't do {n,m} with n > m: / (RegexpError)
      (
        # Match substrings that end in whitespace shorter than limit
        (?:(?:\e\[\d+(?:;\d+)*[@-~])+.?|.(?:\e\[\d+(?:;\d+)*[@-~])*){1,0}
        (?:\s|$)                     # require the limit to end on whitespace
        |
        # Match all continguous whitespace strings
        (?:(?:\e\[\d+(?:;\d+)*[@-~])+.?|.(?:\e\[\d+(?:;\d+)*[@-~])*)+?
        (?:\s|$)
        (?:\s+|$)?
      )
      /
    from /usr/lib/ruby/gems/1.8/gems/rhc-1.10.1/lib/rhc/highline_extensions.rb:40:in `say'
    from /usr/lib/ruby/gems/1.8/gems/rhc-1.10.1/lib/rhc/commands/cartridge.rb:63:in `list'
    from /usr/lib/ruby/gems/1.8/gems/rhc-1.10.1/lib/rhc/highline_extensions.rb:177:in `call'
    from /usr/lib/ruby/gems/1.8/gems/rhc-1.10.1/lib/rhc/highline_extensions.rb:177:in `section'
    from /usr/lib/ruby/gems/1.8/gems/rhc-1.10.1/lib/rhc/highline_extensions.rb:191:in `paragraph'
</pre>
