### PR TITLE
Bug 979992 - Support 'y'/'n' as single character options when interactive

### DIFF
--- a/lib/rhc/commands/cartridge.rb
+++ b/lib/rhc/commands/cartridge.rb
@@ -84,7 +84,7 @@ module RHC::Commands
       rest_app = rest_client.find_application(options.namespace, options.app, :include => :cartridges)
       rest_cartridge = rest_app.add_cartridge(cart)
 
-      success "Success"
+      success "done"
 
       paragraph{ display_cart(rest_cartridge) }
       paragraph{ rest_cartridge.messages.each { |msg| success msg } }

--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -212,7 +212,7 @@ module RHC
     #
 
     def interactive?
-      $stdout.tty? and not options.noprompt
+      $stdin.tty? and $stdout.tty? and not options.noprompt
     end
 
     def debug(*args)
@@ -242,9 +242,20 @@ module RHC
       warn "Warning: #{msg}\n" % ['a warning','an error',1]
     end
 
+    #
+    # By default, agree should take a single character in interactive
+    #
+    def agree(*args, &block)
+      #args.push(interactive?.presence) if args.length == 1
+      block = lambda do |q| 
+        q.validate = /\A(?:y|yes|n|no)\Z/i
+      end unless block_given?
+      super *args, &block
+    end
+
     def confirm_action(question)
       return if options.confirm
-      return if !options.noprompt && paragraph{ agree("#{question} (yes|no): ") }
+      return if !options.noprompt && paragraph{ agree "#{question} (yes|no): " }
       raise RHC::ConfirmationError
     end
 

--- a/spec/rhc/commands/cartridge_spec.rb
+++ b/spec/rhc/commands/cartridge_spec.rb
@@ -10,7 +10,7 @@ describe RHC::Commands::Cartridge do
     run_output.should match(message) if message
   end
 
-  def succeed_with_message(message = "Success")
+  def succeed_with_message(message = "done")
     exit_with_code_and_message(0,message)
   end
 


### PR DESCRIPTION
Fix non-interactive stty behavior.  Keep backwards compatibility of agree for
anyone in non-interactive mode.  Also change "success" on app create to "done"
to be consistent.

@liggitt review
