### PR TITLE
Allow per-project configuration file.

### DIFF
--- a/lib/rhc/config.rb
+++ b/lib/rhc/config.rb
@@ -13,6 +13,9 @@ module RHC
     def local_config_path
       File.join(home_conf_dir, conf_name)
     end
+    def current_config_path
+      File.join(Dir.pwd, '.openshift', conf_name)
+    end
     def ssh_dir
       File.join(home_dir, '.ssh')
     end
@@ -120,6 +123,7 @@ module RHC
       @env_config = RHC::Vendor::ParseConfig.new()
       @global_config = nil
       @local_config = nil
+      @current_config = nil
       @opts_config = nil # config file passed in the options
 
       @default_proxy = nil
@@ -151,7 +155,7 @@ module RHC
 
     def save!(options)
       File.open(path, 'w'){ |f| f.puts self.class.options_to_config(options) }
-      @opts, @opts_config, @local_config, @global_config = nil
+      @opts, @opts_config, @local_config, @local_config, @global_config = nil
       load_config_files
       self
     end
@@ -160,7 +164,7 @@ module RHC
       lazy_init
 
       # evaluate in cascading order
-      configs = [@opts, @opts_config, @env_config, @local_config, @global_config, @defaults]
+      configs = [@opts, @opts_config, @env_config, @current_config, @local_config, @global_config, @defaults]
       result = nil
       configs.each do |conf|
         result = conf[key] if !conf.nil?
@@ -250,6 +254,7 @@ module RHC
     # when a script modifies the config such as in rhc setup
     def config_path
       @config_path ||= local_config_path
+      @config_path ||= current_config_path
     end
     def path
       config_path
@@ -306,6 +311,7 @@ module RHC
       def load_config_files
         @global_config = RHC::Vendor::ParseConfig.new(global_config_path) if File.exists?(global_config_path)
         @local_config = RHC::Vendor::ParseConfig.new(File.expand_path(local_config_path)) if File.exists?(local_config_path)
+        @current_config = RHC::Vendor::ParseConfig.new(File.expand_path(current_config_path)) if File.exists?(current_config_path)
       rescue Errno::EACCES => e
         raise Errno::EACCES.new("Could not open config file: #{e.message}")
       end


### PR DESCRIPTION
RHC tools now look for the global (`/etc`) and local (`~/.openshift`) directories for the `express.conf` file.

In case when you run Origin on your machine, you need to use different libra_server. This could be solved by using`--config` attribute, but that is not really 'user-friendly' ;-)

This patch allows you to place the config file into:

`$PROJECT/.openshift/express.conf`

So you can overide the libra_server just for one project you want to test on origin.
