### PR TITLE
Delete RHC::Commands::Base::inherited

### DIFF
--- a/lib/rhc/commands/base.rb
+++ b/lib/rhc/commands/base.rb
@@ -53,11 +53,6 @@ class RHC::Commands::Base
 
     class InvalidCommand < StandardError ; end
 
-    def self.inherited(klass)
-      unless klass == RHC::Commands::Base
-      end
-    end
-
     def self.method_added(method)
       return if self == RHC::Commands::Base
       return if private_method_defined? method


### PR DESCRIPTION
Delete the definition of RHC::Commands::Base::inherited, which is useless dead code.
