### PR TITLE
rhc/commands/base.rb: Fix whitespace

### DIFF
--- a/lib/rhc/commands/base.rb
+++ b/lib/rhc/commands/base.rb
@@ -157,17 +157,17 @@ class RHC::Commands::Base
       }));
     end
 
-    private
-      def self.options_metadata
-        options[:options] ||= []
-      end
-      def self.args_metadata
-        options[:args] ||= []
-      end
-      def self.aliases
-        options[:aliases] ||= []
-      end
-      def self.options
-        @options ||= {}
-      end
+  private
+    def self.options_metadata
+      options[:options] ||= []
+    end
+    def self.args_metadata
+      options[:args] ||= []
+    end
+    def self.aliases
+      options[:aliases] ||= []
+    end
+    def self.options
+      @options ||= {}
+    end
 end


### PR DESCRIPTION
In RHC::Commands::Base, indent the private section at the same level as the protected section rather than indenting the former so that it appears to be within the latter.
