### PR TITLE
Bug 990484 - Error when hitting max retries

### DIFF
--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -368,6 +368,9 @@ module RHC::Commands
       include RHC::CartridgeHelpers
       include RHC::SSHHelpers
 
+      MAX_RETRIES = 7
+      DEFAULT_DELAY_THROTTLE = 2.0
+
       def require_one_web_cart
         lambda{ |carts|
           match, ambiguous = carts.partition{ |c| not c.is_a?(Array) }

--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -26,9 +26,6 @@ module RHC
 
     extend self
 
-    MAX_RETRIES = 7
-    DEFAULT_DELAY_THROTTLE = 2.0
-
     def decode_json(s)
       RHC::Vendor::OkJson.decode(s)
     end

--- a/lib/rhc/rest/client.rb
+++ b/lib/rhc/rest/client.rb
@@ -8,8 +8,6 @@ require 'benchmark'
 module RHC
   module Rest
 
-    MAX_RETRIES = 5
-
     #
     # These are methods that belong to the API object but are
     # callable from the client for convenience.
@@ -202,6 +200,7 @@ module RHC
       # matching one supported by the server.
       # See #api_version_negotiated
       CLIENT_API_VERSIONS = [1.1, 1.2, 1.3, 1.4, 1.5]
+      MAX_RETRIES = 5
 
       def initialize(*args)
         options = args[0].is_a?(Hash) && args[0] || {}

--- a/spec/rhc/rest_client_spec.rb
+++ b/spec/rhc/rest_client_spec.rb
@@ -202,7 +202,7 @@ module RHC
         end
 
         context "#find_domain" do
-          context "when server does not support SHOW_DOMAIN" do 
+          context "when server does not support SHOW_DOMAIN" do
             before do
               stub_api_request(:any, api_links['LIST_DOMAINS']['relative']).
                 to_return({ :body   => {
@@ -237,7 +237,7 @@ module RHC
 
           context "when server supports SHOW_DOMAIN" do
             let(:api_links){ client_links.merge!(mock_response_links([['SHOW_DOMAIN', 'domains/:name', 'get']])) }
-            before do 
+            before do
               stub_api_request(:any, api_links['SHOW_DOMAIN']['relative'].gsub(/:name/, 'mock_domain_0')).
                 to_return({ :body   => {
                               :type => 'domain',
@@ -257,11 +257,11 @@ module RHC
                                }
                             }.to_json,
                             :status => 200
-                          })                
+                          })
               stub_api_request(:any, api_links['SHOW_DOMAIN']['relative'].gsub(/:name/, 'mock_domain_2')).
                 to_return({ :body => {:messages => [{:exit_code => 127}]}.to_json,
                             :status => 404
-                          })                
+                          })
             end
             it "returns a domain object for matching domain IDs" do
               match = nil
@@ -274,7 +274,7 @@ module RHC
               expect { match = client.find_domain('mock_domain_%^&') }.to_not raise_error
               match.id.should == 'mock_domain_%^&'
               match.class.should == RHC::Rest::Domain
-            end            
+            end
             it "raise an error when no matching domain IDs can be found" do
               expect { client.find_domain('mock_domain_2') }.to raise_error(RHC::Rest::DomainNotFoundException)
             end
@@ -283,11 +283,11 @@ module RHC
 
         context "when server supports LIST_DOMAINS_BY_OWNER" do
           let(:api_links){ client_links.merge!(mock_response_links([['LIST_DOMAINS_BY_OWNER', 'domains', 'get']])) }
-          before do 
+          before do
             stub_api_request(:any, "#{api_links['LIST_DOMAINS_BY_OWNER']['relative']}?owner=@self").
               to_return({ :body   => {
                             :type => 'domains',
-                            :data => [{ 
+                            :data => [{
                               :id    => 'mock_domain_0',
                               :links => mock_response_links(mock_domain_links('mock_domain_0')),
                             }]
@@ -674,7 +674,7 @@ module RHC
         its(:user){ should == username.call }
         its(:passwd){ should == password.call }
         its(:to_str){ should == ["#{username.call}:#{password.call}"].pack('m').tr("\n", '') }
-      end      
+      end
     end
   end
 end

--- a/spec/rhc/rest_spec.rb
+++ b/spec/rhc/rest_spec.rb
@@ -497,7 +497,7 @@ module RHC
         it{ response.should raise_error(RHC::Rest::ConnectionException, "An unexpected error occured: Generic Error") }
       end
 
-      context "with a an unauthorized request" do
+      context "with an unauthorized request" do
         before do
           return_data = {
             :body    => nil,
@@ -507,6 +507,13 @@ module RHC
           stub_request(:get, mock_href).to_return(return_data)
         end
         it("raises not authenticated"){ response.should raise_error(RHC::Rest::UnAuthorizedException, 'Not authenticated') }
+
+        context "when auth will retry forever" do
+          let(:auth){ stub('auth', :to_request => nil) }
+          before{ subject.stub(:auth).and_return(auth); auth.should_receive(:retry_auth?).exactly(4).times.and_return(true) }
+          it("raises not authenticated"){ response.should raise_error(RHC::Rest::UnAuthorizedException, 'Not authenticated') }
+          after{ WebMock.should have_requested(:get, mock_href).times(RHC::Rest::Client::MAX_RETRIES) }
+        end
       end
     end
 


### PR DESCRIPTION
The max retry logic is flawed - if the user exits the retries it returns the
range object (0..5) instead of an error or a value object.  Change logic so
that retries can continue a certain number of times.

@liggitt review plz
