### PR TITLE
create an app for each env set/clear scenario

### DIFF
--- a/features/env.feature
+++ b/features/env.feature
@@ -1,17 +1,21 @@
 @env_var @domain_required
 Feature: Environment Variables Operations
 
-  @init
-  Scenario: Application Creation
-    When a php application is created
-    Then the application should be accessible
+#  @init
+#  Scenario: Application Creation
+#    When a php application is created
+#    Then the application should be accessible
 
   Scenario: Environment variable is set
+    Given a php application is created
+    And the application should be accessible
     When a new environment variable "FOO" is set as "BAR"
     And the existing environment variables are listed
     Then the output environment variables include "FOO=BAR"
 
   Scenario: Environment variables are set
+    Given a php application is created
+    And the application should be accessible
     When a new environment variable "FOO" is set as "BAR"
     And a new environment variable "FOO2" is set as "BAR2"
     And the existing environment variables are listed
@@ -19,6 +23,8 @@ Feature: Environment Variables Operations
     And the output environment variables include "FOO2=BAR2"
 
   Scenario: Environment variable is unset
+    Given a php application is created
+    And the application should be accessible
     When a new environment variable "FOO" is set as "BAR"
     And the existing environment variables are listed
     Then the output environment variables include "FOO=BAR"

--- a/features/step_definitions/env_steps.rb
+++ b/features/step_definitions/env_steps.rb
@@ -9,14 +9,17 @@ When /^'rhc env (\S+)( .*?)?'(?: command)? is run$/ do |subcommand, rest|
 end
 
 When /^a new environment variable "(.*?)" is set as "(.*)"$/ do |name, value|
+  pending "no application provided"  if @app == nil
   step "'rhc env set --env #{name}=#{value} --app #{@app.name}' is run"
 end
 
 When /^an existing environment variable with name "(.*?)" is unset$/ do |name|
+  pending "no application provided"  if @app == nil
   step "'rhc env unset --env #{name} --app #{@app.name}' is run"
 end
 
 Given "the existing environment variables are listed" do
+  pending "no application provided"  if @app == nil
   step "'rhc env list --app #{@app.name}' is run"
 end
 


### PR DESCRIPTION
The env set scenarios require an existing @app object as an instance variable of the scenario.  The object does not persist across scenarios, so create one as a given at the beginning of each scenario

Also, flag a step as 'pending' if no @app instance variable is provided.
