### PR TITLE
Bug 1019294 - ssh_helpers now handle authentication failures

### DIFF
--- a/lib/rhc/deployment_helpers.rb
+++ b/lib/rhc/deployment_helpers.rb
@@ -28,7 +28,8 @@ module RHC
           ssh_ruby(ssh_url.host, ssh_url.user, remote_cmd)
           success "Success"
         rescue
-          warn "Error trying to deploy git ref. You can ssh to your application and try to deploy manually with:\n#{remote_cmd}"
+          ssh_cmd = "ssh -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
+          warn "Error deploying git ref. You can try to deploy manually with:\n#{ssh_cmd}"
           raise
         end
       end
@@ -44,7 +45,8 @@ module RHC
           ssh_send_file_ruby(ssh_url.host, ssh_url.user, remote_cmd, filename)
           success "Success"
         rescue
-          warn "Error trying to deploy local file. You can ssh to your application and try to deploy manually with:\n#{remote_cmd}"
+          ssh_cmd = "ssh -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
+          warn "Error deploying local file. You can try to deploy manually with:\n#{ssh_cmd}"
           raise
         end
       end
@@ -61,7 +63,8 @@ module RHC
           ssh_send_url_ruby(ssh_url.host, ssh_url.user, remote_cmd, file_url)
           success "Success"
         rescue
-          warn "Error trying to deploy file from url. You can ssh to your application and try to deploy manually with:\n#{remote_cmd}"
+          ssh_cmd = "ssh -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
+          warn "Error deploying file from url. You can try to deploy manually with:\n#{ssh_cmd}"
           raise
         end
       end
@@ -76,7 +79,8 @@ module RHC
           ssh_ruby(ssh_url.host, ssh_url.user, remote_cmd)
           success "Success"
         rescue
-          warn "Error trying to activate deployment. You can ssh to your application and try to activate manually with:\n#{remote_cmd}"
+          ssh_cmd = "ssh -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
+          warn "Error activating deployment. You can try to activate manually with:\n#{ssh_cmd}"
           raise
         end
       end

--- a/lib/rhc/exceptions.rb
+++ b/lib/rhc/exceptions.rb
@@ -147,6 +147,12 @@ module RHC
   class ConnectionFailed < Exception
   end
 
+  class SSHAuthenticationFailed < Exception
+    def initialize(host, user)
+      super "Authentication to server #{host} with user #{user} failed"
+    end
+  end
+
   class SSHConnectionRefused < ConnectionFailed
     def initialize(host, user)
       super "The server #{host} refused a connection with user #{user}.  The application may be unavailable.", 1

--- a/lib/rhc/ssh_helpers.rb
+++ b/lib/rhc/ssh_helpers.rb
@@ -199,9 +199,14 @@ module RHC
         #:nocov:
       end
       raise RHC::SSHCommandFailed.new(exit_status) if exit_status != 0
-    rescue Errno::ECONNREFUSED
+    rescue Errno::ECONNREFUSED => e
+      debug_error e
       raise RHC::SSHConnectionRefused.new(host, username)
+    rescue Net::SSH::AuthenticationFailed => e
+      debug_error e
+      raise RHC::SSHAuthenticationFailed.new(host, username)
     rescue SocketError => e
+      debug_error e
       raise RHC::ConnectionFailed, "The connection to #{host} failed: #{e.message}"
     end
 

--- a/spec/rhc/commands/deployment_spec.rb
+++ b/spec/rhc/commands/deployment_spec.rb
@@ -217,6 +217,15 @@ describe RHC::Commands::Deployment do
       end
     end
 
+    context "ssh authentication failure" do
+      before (:each) { Net::SSH.should_receive(:start).exactly(2).times.and_raise(Net::SSH::AuthenticationFailed) }
+      let(:arguments) {['app', 'deploy', 'master', '--app', DEPLOYMENT_APP_NAME]}
+      it "should exit with error" do
+        expect{ run }.to exit_with_code(1)
+        run_output.should match(/Authentication to server test.domain.com with user user failed/)
+      end
+    end
+
   end
 
   describe "activate deployment" do


### PR DESCRIPTION
Net::SSH::AuthenticationFailed will happen when you try to deploy, tail or snapshot and is missing ssh keys, have key permission errors, etc. 
