### PR TITLE
Bug 1017536 - Duplication warning messages when creating scalable app with empty git repo

### DIFF
--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -108,6 +108,7 @@ module RHC::Commands
         # create the main app
         rest_app = create_app(name, cartridges, rest_domain, options.gear_size, options.scaling, options.from_code, env, options.auto_deploy, options.keep_deployments, options.deployment_branch)
         success "done"
+        info "An empty Git repository has been created for your application.  Use 'git push' to add your code." if options.from_code == "empty" || options.from_code == nil
 
         paragraph{ indent{ success rest_app.messages.map(&:strip) } }
       end


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1017536 
When creating new scalable app with empty git repo, will return message that empty git repo has been created twice.

This is second part of the bug fix. First part is at -> https://github.com/openshift/origin-server/pull/4077
