### PR TITLE
remove a dot from help

### DIFF
--- a/lib/rhc/commands/server.rb
+++ b/lib/rhc/commands/server.rb
@@ -2,7 +2,7 @@ module RHC::Commands
   class Server < Base
     suppress_wizard
 
-    summary "Display information about the status of the OpenShift service."
+    summary "Display information about the status of the OpenShift service"
     description <<-DESC
       Retrieves any open issues or notices about the operation of the
       OpenShift service and displays them in the order they were opened.


### PR DESCRIPTION
Very simple patch, removing a dot from help to keep it consistent with other items.
