### PR TITLE
A feature which adds the ability do dump a database using rhc

### DIFF
--- a/lib/rhc/commands/dbdump.rb
+++ b/lib/rhc/commands/dbdump.rb
@@ -5,7 +5,7 @@ require 'rhc/ssh_helpers'
 module RHC::Commands
   class Dbdump < Base
     include RHC::SSHHelpers
-    summary "asdfas"
+    summary "Save the current state of your application's databases locally"
     syntax "<action>"
     description <<-DESC
       Database dumps allow you to export the current state of your application's database


### PR DESCRIPTION
A feature which adds the ability do dump a database using rhc. The corresponding server-side code will come as a separate pull request through origin-server, at https://github.com/openshift/origin-server/pull/4278
