### PR TITLE
Should only wrap when STDOUT is a tty, not STDIN

### DIFF
--- a/lib/rhc/cli.rb
+++ b/lib/rhc/cli.rb
@@ -14,7 +14,7 @@ module RHC
     extend Commander::Delegates
 
     def self.set_terminal
-      $terminal.wrap_at = HighLine::SystemExtensions.terminal_size.first rescue 80 if $stdin.tty?
+      $terminal.wrap_at = HighLine::SystemExtensions.terminal_size.first rescue 80 if $stdout.tty?
       $terminal.wrap_at = nil if $terminal.wrap_at == 0
       #$terminal.page_at = :auto if $stdin.tty? and $stdout.tty?
       # FIXME: ANSI terminals are not default on windows but we may just be

--- a/spec/rhc/cli_spec.rb
+++ b/spec/rhc/cli_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rest_spec_helper'
 require 'rhc/wizard'
 
 describe RHC::CLI do
@@ -174,13 +175,12 @@ describe RHC::CLI do
   describe '#set_terminal' do
     before(:each) { mock_terminal }
     it('should update $terminal.wrap_at') do
-      $stdin.should_receive(:tty?).once.and_return(true)
+      $stdout.should_receive(:tty?).twice.and_return(true)
       HighLine::SystemExtensions.should_receive(:terminal_size).and_return([5])
       expect { RHC::CLI.set_terminal }.to change($terminal, :wrap_at)
     end
     it('should not update $terminal.page_at') do
-      $stdin.should_receive(:tty?).once.and_return(true)
-      $stdout.should_receive(:tty?).once.and_return(true)
+      $stdout.should_receive(:tty?).twice.and_return(true)
       expect { RHC::CLI.set_terminal }.to_not change($terminal, :page_at)
     end
   end


### PR DESCRIPTION
[merge]
