### PR TITLE
Card origin_cartridge_22 - MongoDB version update to 2.4

### DIFF
--- a/cucumber/support/platform_support.rb
+++ b/cucumber/support/platform_support.rb
@@ -3,7 +3,7 @@ if $target_os == 'fedora-19'
       "php"         => { type: "php-5.5", name: "PHP 5.5" },
       "mysql"       => { type: "mariadb-5.5", name: "MariaDB 5.5" },
       "phpmyadmin"  => { type: "phpmyadmin-3", name: "phpMyAdmin 3.5" },
-      "mongodb"     => { type: "mongodb-2.2", name: "MongoDB 2.2" },
+      "mongodb"     => { type: "mongodb-2.4", name: "MongoDB 2.4" },
       "postgresql"  => { type: "postgresql-9.2", name: "PostgreSQL 9.2" },
       "cron"        => { type: "cron-1.4", name: "Cron 1.4" },
       "haproxy"     => { type: "haproxy-1.4", name: "" }
@@ -13,7 +13,7 @@ else
     "php"         => { type: "php-5.3", name: "PHP 5.3" },
     "mysql"       => { type: "mysql-5.1", name: "MySQL 5.1" },
     "phpmyadmin"  => { type: "phpmyadmin-4", name: "phpMyAdmin 4.0" },
-    "mongodb"     => { type: "mongodb-2.2", name: "MongoDB 2.2" },
+    "mongodb"     => { type: "mongodb-2.4", name: "MongoDB 2.4" },
     "postgresql"  => { type: "postgresql-8.4", name: "PostgreSQL 8.4" },
     "cron"        => { type: "cron-1.4", name: "Cron 1.4" },
     "haproxy"     => { type: "haproxy-1.4", name: "" }


### PR DESCRIPTION
MongoDB version update from 2.2 to 2.4

This PR depends on PRs from other openshift repositories, and should be merged together with them.

PRs:
- li repo : https://github.com/openshift/li/pull/2313
- origin-server repo : https://github.com/openshift/origin-server/pull/4602
