### PR TITLE
Have rhc --debug also put ssh into debugin mode

### DIFF
--- a/lib/rhc/commands/ssh.rb
+++ b/lib/rhc/commands/ssh.rb
@@ -39,11 +39,7 @@ module RHC::Commands
 
         debug "Using user specified SSH: #{options.ssh}" if options.ssh
 
-        if debug?
-          command_line = [ ssh.split << "-vvv" , rest_app.ssh_string.to_s, command ].flatten.compact
-        else
-          command_line = [ ssh.split, rest_app.ssh_string.to_s, command].flatten.compact
-        end
+        command_line = [ ssh.split, ('-vvv' if debug?), rest_app.ssh_string.to_s, command ].flatten.compact
 
         debug "Invoking Kernel.exec with #{command_line.inspect}"
         Kernel.send(:exec, *command_line)

--- a/spec/rhc/commands/ssh_spec.rb
+++ b/spec/rhc/commands/ssh_spec.rb
@@ -28,6 +28,21 @@ describe RHC::Commands::Ssh do
       it { expect{ run }.to exit_with_code(0) }
     end
   end
+  
+  describe 'ssh without command including debugging' do
+    let(:arguments) { ['app', 'ssh', 'app1', '--debug'] }
+
+    context 'when run' do
+      before(:each) do
+        @domain = rest_client.add_domain("mockdomain")
+        @domain.add_application("app1", "mock_type")
+        Kernel.should_receive(:exec).with("ssh", "-vvv", "fakeuuidfortestsapp1@127.0.0.1").and_return(0)
+      end
+      # It would be nice if this checked for the debug[123]: messages from standard error but im not sure how to look for that.
+      it { run_output.should match("Connecting to fakeuuidfortestsapp") }
+      it { expect{ run }.to exit_with_code(0) }
+    end
+  end
 
   describe 'app ssh with command' do
     let(:arguments) { ['app', 'ssh', 'app1', 'ls', '/tmp'] }


### PR DESCRIPTION
If RHC debuging is enabled SSH debugging should also be enabled. This keeps you from having to debug rhc as the issue or if ssh is the issue. With this it can be examined all at the same time. 
