### PR TITLE
Using headers with RHC

### DIFF
--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -113,6 +113,9 @@ module RHC
     global_option '--server HOSTNAME', String, 'An OpenShift server hostname (default: openshift.redhat.com)'
     global_option '-k', '--insecure', "Allow insecure SSL connections.  Potential security risk.", :hide => true
 
+    global_option '-H','--headers HEADER', String,"allow header transmissions" do |headers|
+        raise RHC::Exception,"header must be a string" unless headers.instance_of? String
+        end
     global_option '--limit INTEGER', Integer, "Maximum number of simultaneous operations to execute.", :hide => true
     global_option '--raw', "Do not format the output from the requested operations.", :hide => true
     global_option '--always-prefix', "Include the gear prefix on all output from the server.", :hide => true
@@ -199,11 +202,21 @@ module RHC
       return nil if token_store_user_key.nil?
       token_store.get(token_store_user_key, options.server)
     end
+    
+    def headers
+       headers ={}
+       options.headers.to_s.split(',').each do |pair|
+       key,value = pair.split(/:/)
+       headers[key] = value
+      end
+      return headers
+    end
 
     def client_from_options(opts)
       RHC::Rest::Client.new({
           :url => openshift_rest_endpoint.to_s,
           :debug => options.debug,
+          :headers => headers,
           :timeout => options.timeout,
           :warn => BOUND_WARNING,
         }.merge!(ssl_options).merge!(opts))


### PR DESCRIPTION
If you were looking for a method which would allow you to use headers with the RHC tool , the configuration of a global option might be a clever choice. In order to do that , adding some lines of code into the file lib/rhc/helpers.rb is a must.

Find out a suggestion for the changes to make below!
