### PR TITLE
Bug 1132651 - Backtrace and 'error' reported with --debug flag even when application creation is successfu

### DIFF
--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -444,7 +444,7 @@ module RHC
           debug("Checking for #{host} from Resolv::Hosts: #{result.inspect}") if debug?
           result
         rescue => e
-          debug "Application could not be resolved through Hosts file:  #{e.message}(#{e.class})\n  Attempting DNS resolution."
+          debug "Application could not be resolved through Hosts file:  #{e.message}(#{e.class})\n #{e.backtrace.join("\n ")}\n Attempting DNS resolution."
         end
       end
     end


### PR DESCRIPTION
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1132651
Removed unnecessary backtrace and improved debug message to decrease confusion among users unfamilar with rhc code.
