### PR TITLE
Make a scalable application HA

### DIFF
--- a/autocomplete/rhc_bash
+++ b/autocomplete/rhc_bash
@@ -214,7 +214,7 @@ _rhc()
 
       "rhc app create")
         if [[ "$cur" == -* ]]; then
-          opts="--app --dns --enable-jenkins --env --from-app --from-code --gear-size --git --namespace --no-dns --no-git --no-keys --no-scaling --region --repo --scaling --type"
+          opts="--app --dns --enable-jenkins --env --from-app --from-code --gear-size --git --make-ha --namespace --no-dns --no-git --no-keys --no-scaling --region --repo --scaling --type"
         else
           opts=""
         fi
@@ -358,7 +358,7 @@ _rhc()
 
       "rhc app-create")
         if [[ "$cur" == -* ]]; then
-          opts="--app --dns --enable-jenkins --env --from-app --from-code --gear-size --git --namespace --no-dns --no-git --no-keys --no-scaling --region --repo --scaling --type"
+          opts="--app --dns --enable-jenkins --env --from-app --from-code --gear-size --git --make-ha --namespace --no-dns --no-git --no-keys --no-scaling --region --repo --scaling --type"
         else
           opts=""
         fi
@@ -798,7 +798,7 @@ _rhc()
 
       "rhc create-app")
         if [[ "$cur" == -* ]]; then
-          opts="--app --dns --enable-jenkins --env --from-app --from-code --gear-size --git --namespace --no-dns --no-git --no-keys --no-scaling --region --repo --scaling --type"
+          opts="--app --dns --enable-jenkins --env --from-app --from-code --gear-size --git --make-ha --namespace --no-dns --no-git --no-keys --no-scaling --region --repo --scaling --type"
         else
           opts=""
         fi


### PR DESCRIPTION
First follow these to allow multiple HAProxies on a Node Host

1. Open the /etc/openshift/broker.conf file on the broker host and set the
    ALLOW_MULTIPLE_HAPROXY_ON_NODE value to true:

    ALLOW_MULTIPLE_HAPROXY_ON_NODE="true"

2. Restart the openshift-broker service:

     service openshift-broker restart

3. Run the following command to make a scalable application HA
  
     rhc app-create your-app-name cartridge-name  -s  -x 
        OR
    rhc app-create your-app-name cartidge-name -s --make-ha

4. Check if you have 2 HA-proxies on each of the 2 gears created by running the following command-
    
    rhc app-show your app name --gears
