### PR TITLE
Snapshot save for deployment on windows

### DIFF
--- a/lib/rhc/ssh_helpers.rb
+++ b/lib/rhc/ssh_helpers.rb
@@ -268,7 +268,7 @@ module RHC
         else
           Net::SSH.start(ssh_uri.host, ssh_uri.user) do |ssh|
             File.open(filename, 'wb') do |file|
-              ssh.exec! "snapshot" do |channel, stream, data|
+              ssh.exec! snapshot_cmd do |channel, stream, data|
                 if stream == :stdout
                   file.write(data)
                 else


### PR DESCRIPTION
The Windows part of snapshot save was always calling "snapshot" in the
node, not taking into account if the user had asked --deployment.

Bug 1170105 - rhc snapshot save --deployment does not work on windows
