### PR TITLE
Bug 1149016 - allow spaces in paths for --ssh flag but still allow argum...

### DIFF
--- a/lib/rhc/commands/ssh.rb
+++ b/lib/rhc/commands/ssh.rb
@@ -15,6 +15,10 @@ module RHC::Commands
 
       You may run a specific SSH command by passing one or more arguments, or use a
       different SSH executable or pass options to SSH with the '--ssh' option.
+
+      To use the '--ssh' flag with an SSH executable path containing a space, wrap
+      the executable path with double quotes:
+      --ssh '"C:\\path with spaces\\ssh"'
       DESC
     syntax "[--ssh path_to_ssh_executable] [--gears] [<app> --] <command>"
     takes_application :argument => true
@@ -42,16 +46,7 @@ module RHC::Commands
         command_line = [RHC::Helpers.split_path(ssh), ('-vv' if debug?), rest_app.ssh_string.to_s, command].flatten.compact
 
         debug "Invoking Kernel.exec with #{command_line.inspect}"
-        begin
-          Kernel.send(:exec, *command_line)
-        rescue Errno::ENOENT
-          debug "SSH executable #{ssh.inspect} not found, splitting and trying again..."
-
-          command_line = [ssh.chomp('"').reverse.chomp('"').reverse.split(' '), ('-vv' if debug?), rest_app.ssh_string.to_s, command].flatten.compact
-          debug "Invoking Kernel.exec with #{command_line.inspect}"
-
-          Kernel.send(:exec, *command_line)
-        end
+        Kernel.send(:exec, *command_line)
       end
     end
 

--- a/lib/rhc/ssh_helpers.rb
+++ b/lib/rhc/ssh_helpers.rb
@@ -475,10 +475,10 @@ module RHC
           raise RHC::InvalidSSHExecutableException.new("No system SSH available. Please use the --ssh option to specify the path to your SSH executable, or install SSH.#{windows? ? ' We recommend this free application: Git for Windows - a basic git command line and GUI client http://msysgit.github.io/.' : ''}") unless ssh_cmd or has_ssh?
         end
       else
-        bin_path = path.split(' ').first
+        bin_path = split_path(path)[0]
         raise RHC::InvalidSSHExecutableException.new("SSH executable '#{bin_path}' does not exist.") unless File.exist?(bin_path) or File.exist?(path) or exe?(bin_path)
         raise RHC::InvalidSSHExecutableException.new("SSH executable '#{bin_path}' is not executable.") unless File.executable?(path) or File.executable?(bin_path) or exe?(bin_path)
-        path =~ / / ? '"' + path + '"' : path
+        path
       end
     end
 

--- a/spec/rhc/commands/ssh_spec.rb
+++ b/spec/rhc/commands/ssh_spec.rb
@@ -171,8 +171,8 @@ describe RHC::Commands::Ssh do
     end
   end
 
-  describe 'app ssh custom ssh with spaces' do
-    let(:arguments) { ['app', 'ssh', 'app1', '--ssh', '/path/to/ssh --with_custom_flag'] }
+  describe 'app ssh custom ssh with spaces and arguments' do
+    let(:arguments) { ['app', 'ssh', 'app1', '--ssh', '"/path/to /ssh" --with_custom_flag'] }
     context 'when custom ssh does not exist as a path' do
       before(:each) do
         @domain = rest_client.add_domain("mockdomain")
@@ -181,8 +181,7 @@ describe RHC::Commands::Ssh do
         File.should_receive(:exist?).at_least(1).and_return(true)
         File.should_receive(:executable?).at_least(1).and_return(true)
         subject.class.any_instance.stub(:discover_git_executable).and_return('git')
-        Kernel.should_receive(:exec).with('/path/to/ssh --with_custom_flag', "fakeuuidfortestsapp1@127.0.0.1").once.times.and_raise(Errno::ENOENT)
-        Kernel.should_receive(:exec).with('/path/to/ssh', '--with_custom_flag', "fakeuuidfortestsapp1@127.0.0.1").once.times.and_return(0)
+        Kernel.should_receive(:exec).with("/path/to /ssh", '--with_custom_flag', "fakeuuidfortestsapp1@127.0.0.1").once.times.and_return(0)
       end
       it { expect { run }.to exit_with_code(0) }
     end


### PR DESCRIPTION
...ents.

Executable path must be quoted within the string with escaped quotes if it contains spaces in the path