### PR TITLE
bug 1187806: no need for no_auth

### DIFF
--- a/lib/rhc/rest/api.rb
+++ b/lib/rhc/rest/api.rb
@@ -14,7 +14,6 @@ module RHC
           :url => client.url,
           :method => :get,
           :accept => :json,
-          :no_auth => true,
         })
         debug "Server supports API versions #{@server_api_versions.join(', ')}"
 
@@ -28,7 +27,6 @@ module RHC
               :method => :get,
               :accept => :json,
               :api_version => api_version_negotiated,
-              :no_auth => true,
             })
           end
         else


### PR DESCRIPTION
@liggitt can you explain what no_auth was for, in the context of this x509 bug, where the effect seems to be that the client stops sending the cert once the user is set up:
https://bugzilla.redhat.com/show_bug.cgi?id=1187806

I'm apparently too dense to understand the tests in commit 9ceb5e45 where you introduced this. I don't particularly want to introduce a no_no_auth setting. An always_auth client setting might be OK, but it would be *really* nice if the server could indicate to the client that it should always auth and ignore tokens.