### PR TITLE
Add "always_auth" config option

### DIFF
--- a/lib/rhc/config.rb
+++ b/lib/rhc/config.rb
@@ -61,8 +61,9 @@ module RHC
       :insecure                 => [nil,               :boolean,      "If true, certificate errors will be ignored.\nWARNING: This may allow others to eavesdrop on your communication with OpenShift."],
       :ssl_version              => [nil,               nil,           'The SSL protocol version to use when connecting to this server'],
       :ssl_client_cert_file     => [nil,               :path_to_file, 'A client certificate file for use with your server'],
-      :ssl_client_key_file      => [nil, :path_to_file, 'The corresponding key for the client certificate'],
+      :ssl_client_key_file      => [nil,               :path_to_file, 'The corresponding key for the client certificate'],
       :ssl_ca_file              => [nil,               :path_to_file, 'A file containing CA one or more certificates'],
+      :always_auth              => [nil,               :boolean,      'If true, the client will use an authenticated connection for all requests. Useful for certain client certificate configurations.'],
     }
 
     def self.options_to_config(options, args=OPTIONS.keys)

--- a/lib/rhc/rest/api.rb
+++ b/lib/rhc/rest/api.rb
@@ -14,7 +14,7 @@ module RHC
           :url => client.url,
           :method => :get,
           :accept => :json,
-          :no_auth => true,
+          :no_auth => !RHC::Config['always_auth'],
         })
         debug "Server supports API versions #{@server_api_versions.join(', ')}"
 
@@ -28,7 +28,7 @@ module RHC
               :method => :get,
               :accept => :json,
               :api_version => api_version_negotiated,
-              :no_auth => true,
+              :no_auth => !RHC::Config['always_auth'],
             })
           end
         else

--- a/spec/rhc/config_spec.rb
+++ b/spec/rhc/config_spec.rb
@@ -69,9 +69,10 @@ describe RHC::Config do
           'ssl_ca_file' => 'file2',
           'timeout' => '1',
           'use_authorization_tokens' => 'true',
+          'always_auth' => 'false',
         }
       end
-      its(:to_options){ should == {:insecure => true, :timeout => 1, :ssl_ca_file => 'file2', :ssl_client_cert_file => 'file1', :rhlogin => 'user', :password => 'pass', :server => 'test.com', :use_authorization_tokens => true} }
+      its(:to_options){ should == {:insecure => true, :timeout => 1, :ssl_ca_file => 'file2', :ssl_client_cert_file => 'file1', :rhlogin => 'user', :password => 'pass', :server => 'test.com', :use_authorization_tokens => true, :always_auth => false} }
     end
   end
 


### PR DESCRIPTION
Add `always_auth` config parameter, so that all REST API calls include authentication. This is useful for sites where x509 client cert authentication is configured for every REST API URL.