### PR TITLE
Parse boolean option `always_auth`

### DIFF
--- a/lib/rhc/rest/api.rb
+++ b/lib/rhc/rest/api.rb
@@ -10,11 +10,12 @@ module RHC
         @server_api_versions = []
         debug "Client supports API versions #{preferred_api_versions.join(', ')}"
         @client_api_versions = preferred_api_versions
+        always_auth = RHC::Helpers.to_boolean(RHC::Config['always_auth'], false)
         @server_api_versions, @current_api_version, links = api_info({
           :url => client.url,
           :method => :get,
           :accept => :json,
-          :no_auth => !RHC::Config['always_auth'],
+          :no_auth => !always_auth,
         })
         debug "Server supports API versions #{@server_api_versions.join(', ')}"
 
@@ -28,7 +29,7 @@ module RHC
               :method => :get,
               :accept => :json,
               :api_version => api_version_negotiated,
-              :no_auth => !RHC::Config['always_auth'],
+              :no_auth => !always_auth,
             })
           end
         else


### PR DESCRIPTION
As noted in https://bugzilla.redhat.com/show_bug.cgi?id=1187806#c11, the
`always_auth` option wasn't being properly parsed as a boolean. This
change fixes that by storing the parsed value temporarily.