### PR TITLE
app show: highlight carts with endpoints

### DIFF
--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -429,10 +429,16 @@ module RHC::Commands
         domain, app = discover_domain_and_app
         gear_info = rest_client.find_application_gear_groups_endpoints(domain, app).map do |group|
           group.gears.map do |gear|
+            color_cart = if gear['endpoints'].present?
+              e = gear['endpoints'].collect{ |c| c['cartridge_name'] }.uniq
+              lambda { |c| e.include?(c) ? color(c, :green) : c }
+            else
+              lambda { |c| c }
+            end
             [
               gear['id'],
               gear['state'] == 'started' ? color(gear['state'], :green) : color(gear['state'], :yellow),
-              (gear['endpoints'].blank? ? group.cartridges : gear['endpoints']).collect{ |c| c['cartridge_name'] || c['name'] }.join(' '),
+              group.cartridges.collect{ |c| color_cart.call(c['name']) }.join(' '),
               group.gear_profile,              
               gear['region'],
               gear['zone'],

--- a/spec/rhc/helpers_spec.rb
+++ b/spec/rhc/helpers_spec.rb
@@ -60,7 +60,7 @@ describe AllRhcHelpers do
     it("should be colorized") do
       message = "this is #{_color} -"
       output = capture{ subject.send(method,message) }
-      output.should be_colorized(message,_color)
+      output.chomp.should be_colorized(message,_color)
     end
     it("should return true"){ subject.send(method,'anything').should be_true }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -567,8 +567,7 @@ module ColorMatchers
       [
         ansi_code(color),
         msg,
-        ansi_code(:clear),
-        "\n"
+        ansi_code(:clear)
       ].join('')
     end
   end


### PR DESCRIPTION
Modify `app show --gears` (1) to list all cartridges in the gear group for a given gear and (2) to indicate cartridges that expose endpoints on the gear by highlighting those cartridges' names in green.

The REST API does not provide an interface to determine which cartridges are running on a gear; rather, we can only determine the gear group that is associated with a gear and the endpoints that cartridges on that gear are exposing.  On the one hand, the gear group associated with a given gear may include cartridges that are not actually on that particular gear, and so if we list the cartridges in the gear group, we may list cartridges that are not actually on the gear.  On the other hand, a cartridge may be on a gear but not be exposing any endpoints (e.g., the cron cartridge), and so if we list only the cartridges that are exposing endpoints on the gear, we may fail to list some cartridges that are in fact on the gear.

Prior to commit d858baefbad9d0d85ee46fa05a8642d169cad039, we chose the first option of listing all cartridges in the gear group, including false positives.  Commit d858baefbad9d0d85ee46fa05a8642d169cad039 changed `app show --gears` to implement the second option of listing cartridges that were exposing endpoints, which caused false negatives, as well as duplicate entries for a cartridge that were exposing multiple endpoints.

With this commit, a cartridge may be listed for a gear even if it is not actually on that gear, but the green highlight or absence thereof should make it clear in the case of a cartridge that normally exposes endpoints whether that cartridge really is present on a gear or whether it is merely associated with the gear through the gear group but is not actually present on the particular gear.

This commit addresses bug 1125926 and bug 1130028.