### PR TITLE
Report error when a syntatically incorrect env var is provided on app-create

### DIFF
--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -101,6 +101,12 @@ module RHC::Commands
       end.join(', ')
 
       env = collect_env_vars(arg_envs.concat(Array(options.env)))
+      if options.env && env.empty?
+        raise RHC::EnvironmentVariableNotProvidedException.new(
+        "Environment variable(s) not provided.\n" +
+        "Please provide at least one environment variable using the syntax VARIABLE=VALUE. VARIABLE can only contain letters, digits and underscore ('_') and can't begin with a digit.")
+      end
+
       if env.present? && !rest_domain.supports_add_application_with_env_vars?
         env = []
         warn "Server does not support environment variables."

--- a/spec/rhc/commands/app_spec.rb
+++ b/spec/rhc/commands/app_spec.rb
@@ -990,5 +990,16 @@ describe RHC::Commands::App do
       end
     end
 
+    [['app', 'create', 'app1', 'mock_standalone_cart-1', '-e', 'FOOBAR'],
+     ['app', 'create', 'app1', 'mock_standalone_cart-1', '--env', 'FOOBAR'],
+     ['app', 'create', 'app1', 'mock_standalone_cart-1', '-eFOOBAR']
+    ].each_with_index do |args, i|
+      context "when run with syntactically incorrect env vars #{i}" do
+        let(:arguments) { args }
+        it { expect { run }.to exit_with_code(159) }
+        it { run_output.should match(/Environment variable\(s\) not provided.\nPlease provide at least one environment variable using the syntax VARIABLE=VALUE\. VARIABLE can only contain letters, digits and underscore \('_'\) and can't begin with a digit\./) }
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Bug 1232921
https://bugzilla.redhat.com/show_bug.cgi?id=1232921

When creating an application with an environment variable, report an error if the environment variable is not provided with the proper syntax. Previously, incorrect environment variables were ignored and the application creation continued.