### PR TITLE
Bug 1216206 - Always_auth should be able to be passed to 'setup'

### DIFF
--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -135,6 +135,7 @@ module RHC
     global_option('--timeout SECONDS', Integer, 'The timeout for operations') do |value|
       raise RHC::Exception, "Timeout must be a positive integer" unless value > 0
     end
+    global_option '--always-auth', "Always use authentication when making OpenShift API requests.", :hide => true
     global_option '--noprompt', "Suppress all interactive operations command", :hide => true do
       $terminal.page_at = nil
     end
@@ -217,6 +218,7 @@ module RHC
           :headers => parse_headers(options.header),
           :timeout => options.timeout,
           :warn => BOUND_WARNING,
+          :api_always_auth => options.always_auth
         }.merge!(ssl_options).merge!(opts))
     end
 

--- a/lib/rhc/rest/api.rb
+++ b/lib/rhc/rest/api.rb
@@ -10,12 +10,11 @@ module RHC
         @server_api_versions = []
         debug "Client supports API versions #{preferred_api_versions.join(', ')}"
         @client_api_versions = preferred_api_versions
-        always_auth = RHC::Helpers.to_boolean(RHC::Config['always_auth'], false)
         @server_api_versions, @current_api_version, links = api_info({
           :url => client.url,
           :method => :get,
           :accept => :json,
-          :no_auth => !always_auth,
+          :no_auth => !client.api_always_auth
         })
         debug "Server supports API versions #{@server_api_versions.join(', ')}"
 
@@ -29,7 +28,7 @@ module RHC
               :method => :get,
               :accept => :json,
               :api_version => api_version_negotiated,
-              :no_auth => !always_auth,
+              :no_auth => !client.api_always_auth
             })
           end
         else

--- a/lib/rhc/rest/client.rb
+++ b/lib/rhc/rest/client.rb
@@ -378,6 +378,7 @@ module RHC
         @debug ||= false
 
         @auth = options.delete(:auth)
+        @api_always_auth = options.delete(:api_always_auth)
 
         self.headers.merge!(options.delete(:headers)) if options[:headers]
         self.options.merge!(options)
@@ -387,6 +388,10 @@ module RHC
 
       def url
         @end_point
+      end
+
+      def api_always_auth
+        @api_always_auth
       end
 
       def api


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1216206

The always_auth option could be configured in the rhc configuration prior to running 'rhc setup' to enable always authenticating to openshift api endpoints. This change allows the '--always-auth' option to be passed in with 'rhc setup' to ensure every request is authenticated during setup and that 'always_auth=true' is added to the configuration file. This eliminates the need to manually modify the 'always_auth' directive in the configuration file before running setup.

This fix also allows the '--always-auth' option to be passed globally, with any rhc command.