### PR TITLE
Fix create-app --from-app test timeout

### DIFF
--- a/features/app_feature.rb
+++ b/features/app_feature.rb
@@ -11,6 +11,18 @@ describe "rhc app scenarios" do
     let(:app){ @app }
 
     it "should clone successfully" do
+      # The following works around an issue with strict host key checking.
+      # create-app --from-app uses SSH to copy the application.  However,
+      # this test uses a new application, so without this workaround, create-app
+      # --from-app will be trying to log into the application for the first
+      # time, and so SSH will not recognize the host key and will prompt for
+      # confirmation, causing the test to hang and eventually time out.  To work
+      # around the problem, we tell rhc to initiate an SSH connection using
+      # GIT_SSH (which disables strict host key checking), which will cause SSH
+      # to add the host to ~/.ssh/known_hosts, which will allow the subsequent
+      # create-app --from-app command to succeed.
+      rhc 'ssh', '--ssh', ENV['GIT_SSH'], app.name, '--', 'true'
+
       app_name = "clone#{random}"
       r = rhc 'create-app', app_name, '--from-app', app.name
       r.stdout.should match /Domain:\s+#{app.domain}/


### PR DESCRIPTION
Perform a `git-clone` before running `create-app --from-app`.

`git-clone` uses Git and thus respects `GIT_SSH`, which we set to disable strict host key checking.  `create-app` initiates an SSH session itself, without respecting `GIT_SSH`.  If we use `create-app` without having previously connected to the application using SSH, SSH will not recognize the host
key, and so it will prompt the user before continuing, causing the test to hang until it times out.

[test]