### PR TITLE
Quote as necessary when writing configuration

### DIFF
--- a/lib/rhc/config.rb
+++ b/lib/rhc/config.rb
@@ -84,7 +84,7 @@ module RHC
       when :integer, :boolean
         value.nil? ? "<#{type}>" : value
       else
-        value.nil? ? "<#{type || 'string'}>" : value
+        value.nil? ? "<#{type || 'string'}>" : value.match(/\W/) ? "\"#{value}\"" : value
       end
     end
 


### PR DESCRIPTION
When writing out configuration files, enclose values in double-quotes if they include non-word characters.

Note: We use `ParseConfig` to read in the configuration files, which interprets the following:

````
default_rhlogin=""test" \ test"
````

as setting `default_rhlogin` to the literal value

````
"test" \ test
````

including the double-quotation marks, spaces, and backslash verbatim.

This commit fixes bug 1135403.