### PR TITLE
change the usage for `cartridge start` to say starting

### DIFF
--- a/lib/rhc/commands/cartridge.rb
+++ b/lib/rhc/commands/cartridge.rb
@@ -147,7 +147,7 @@ module RHC::Commands
 
     summary "Start a cartridge"
     syntax "<cartridge> [--namespace NAME] [--app NAME]"
-    argument :cart_type, "The name of the cartridge you are stopping", ["-c", "--cartridge cartridge"]
+    argument :cart_type, "The name of the cartridge you are starting", ["-c", "--cartridge cartridge"]
     takes_application
     alias_action :"app cartridge start", :root_command => true, :deprecated => true
     def start(cartridge)


### PR DESCRIPTION
the usage for `rhc cartridge start -h` shows the following (emphasis mine):

```
$ rhc cartridge start -h
Usage: rhc cartridge-start <cartridge> [--namespace NAME] [--app NAME]

Start a cartridge


Options
  -a, --app NAME            Name of an application
  -n, --namespace NAME      Name of a domain
  -c, --cartridge cartridge The name of the cartridge you are stopping

Global Options
  -l, --rhlogin LOGIN       OpenShift login
  -p, --password PASSWORD   OpenShift password
  --token TOKEN             An authorization token for accessing your account.
  --server HOSTNAME         An OpenShift server hostname (default: openshift.redhat.com)
  --timeout SECONDS         The timeout for operations

  See 'rhc help options' for a full list of global options.
  
```

this line:

```
  -c, --cartridge cartridge The name of the cartridge you are stopping
```

should say:

```
  -c, --cartridge cartridge The name of the cartridge you are starting
```