### PR TITLE
Allow an SSH executable to be specified globally

### DIFF
--- a/lib/rhc/commands/snapshot.rb
+++ b/lib/rhc/commands/snapshot.rb
@@ -18,11 +18,10 @@ module RHC::Commands
     default_action :help
 
     summary "Save a snapshot of your app to disk"
-    syntax "<application> [--filepath FILE] [--ssh path_to_ssh_executable]"
+    syntax "<application> [--filepath FILE]"
     takes_application :argument => true
     option ["-f", "--filepath FILE"], "Local path to save tarball (default: ./$APPNAME.tar.gz)"
     option ["--deployment"], "Snapshot as a deployable file which can be deployed with 'rhc deploy'"
-    option ["--ssh PATH"], "Full path to your SSH executable with additional options"
     alias_action :"app snapshot save", :root_command => true, :deprecated => true
     def save(app)
 
@@ -38,10 +37,9 @@ module RHC::Commands
     end
 
     summary "Restores a previously saved snapshot"
-    syntax "<application> [--filepath FILE] [--ssh path_to_ssh_executable]"
+    syntax "<application> [--filepath FILE]"
     takes_application :argument => true
     option ["-f", "--filepath FILE"], "Local path to restore tarball"
-    option ["--ssh PATH"], "Full path to your SSH executable with additional options"
     alias_action :"app snapshot restore", :root_command => true, :deprecated => true
     def restore(app)
       rest_app = find_app

--- a/lib/rhc/commands/ssh.rb
+++ b/lib/rhc/commands/ssh.rb
@@ -14,16 +14,20 @@ module RHC::Commands
       other gears run 'rhc show-app --gears' to get a list of their SSH hosts.
 
       You may run a specific SSH command by passing one or more arguments, or use a
-      different SSH executable or pass options to SSH with the '--ssh' option.
+      different SSH executable or pass options to SSH with the '--ssh' option or 'ssh'
+      configuration directive.
 
       To use the '--ssh' flag with an SSH executable path containing a space, wrap
       the executable path with double quotes:
       --ssh '"C:\\path with spaces\\ssh"'
+
+      The SSH executable path, as well as any command options, can also be specified in
+      the rhc configuration file with:
+      ssh="/path/to/executable [--example option]"
       DESC
-    syntax "[--ssh path_to_ssh_executable] [--gears] [<app> --] <command>"
+    syntax "[--gears] [<app> --] <command>"
     takes_application :argument => true
     argument :command, "Command to run in the application's SSH session", ['--command COMMAND'], :type => :list, :optional => true
-    option ["--ssh PATH"], "Path to your SSH executable or additional options"
     option ["--gears"], "Execute this command on all gears in the app.  Requires a command."
     option ["--limit INTEGER"], "Limit the number of simultaneous SSH connections opened with --gears (default: 5).", :type => Integer, :default => 5
     option ["--raw"], "Output only the data returned by each host, no hostname prefix."

--- a/lib/rhc/config.rb
+++ b/lib/rhc/config.rb
@@ -29,12 +29,12 @@ module RHC
 
   #
   # Responsible for encapsulating the loading and retrieval of OpenShift
-  # configuration files and converting them to commandline option 
+  # configuration files and converting them to commandline option
   # equivalents.  It also provides the converse option - converting a set
   # of commandline options back into a config file.
   #
   # In general, the values stored in the config should be identical (require
-  # little or no type conversion) to their option form.  As new global 
+  # little or no type conversion) to their option form.  As new global
   # options are added, only this class should have to change to persist that
   # option.
   #
@@ -63,6 +63,7 @@ module RHC
       :ssl_client_cert_file     => [nil,               :path_to_file, 'A client certificate file for use with your server'],
       :ssl_client_key_file      => [nil,               :path_to_file, 'The corresponding key for the client certificate'],
       :ssl_ca_file              => [nil,               :path_to_file, 'A file containing CA one or more certificates'],
+      :ssh                      => [nil,               :path_to_file, 'Path to a ssh executable and command options to use when performing ssh commands. When providing options, ensure path and options are enclosed in single or double quotes.'],
       :always_auth              => [nil,               :boolean,      'If true, the client will use an authenticated connection for all requests. Useful for certain client certificate configurations.'],
     }
 
@@ -75,7 +76,7 @@ module RHC
         arr << "#{value.nil? ? '#' : ''}#{opts[0] || name}=#{self.type_to_config(opts[1], value)}"
         arr << ""
         arr
-      end.unshift(!args.nil? && args.length < OPTIONS.length ? 
+      end.unshift(!args.nil? && args.length < OPTIONS.length ?
         ["# Check servers.yml for detailed server configuration", ""] : nil).flatten.compact.join("\n")
     end
 
@@ -166,9 +167,9 @@ module RHC
     end
 
     def save!(options, fields=nil)
-      File.open(path, 'w') do |f| 
+      File.open(path, 'w') do |f|
         f.puts self.class.options_to_config(
-          options, 
+          options,
           fields
         )
       end
@@ -193,12 +194,12 @@ module RHC
     # individual configs will be evaluated in the following cascading order
     def configs_cascade
       [
-        @opts, 
-        @opts_config, 
-        @env_config, 
-        @additional_config, 
-        @local_config, 
-        @global_config, 
+        @opts,
+        @opts_config,
+        @env_config,
+        @additional_config,
+        @local_config,
+        @global_config,
         @defaults
       ]
     end

--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -132,6 +132,7 @@ module RHC
       debug certificate_key(value)
     end
 
+    global_option '--ssh STRING', 'Path to a ssh executable and command options to use when performing ssh commands. When providing options, ensure path and options are enclosed in single or double quotes.', :hide => true
     global_option('--timeout SECONDS', Integer, 'The timeout for operations') do |value|
       raise RHC::Exception, "Timeout must be a positive integer" unless value > 0
     end

--- a/lib/rhc/ssh_helpers.rb
+++ b/lib/rhc/ssh_helpers.rb
@@ -254,7 +254,7 @@ module RHC
 
       snapshot_cmd = for_deployment ? 'gear archive-deployment' : 'snapshot'
       ssh_cmd = "#{ssh_executable} #{ssh_uri.user}@#{ssh_uri.host} '#{snapshot_cmd}' > #{filename}"
-      ssh_stderr = " 2>/dev/null"
+      ssh_stderr = debug? ? '' : ' 2>/dev/null'
       debug ssh_cmd
 
       # Default timeout is 30 minutes, more than enough time to ensure the snapshot is copied successfully.
@@ -263,11 +263,13 @@ module RHC
       say "Pulling down a snapshot of application '#{app.name}' to #{filename} ... "
 
       begin
-        if !RHC::Helpers.windows?
+        if !RHC::Helpers.windows? || options.ssh
+          debug "Using user specified SSH: #{ssh_executable}" if options.ssh
+
           status = 1
           output = ""
           Timeout::timeout(exec_timeout) do
-            status, output = exec(ssh_cmd + (debug? ? '' : ssh_stderr))
+            status, output = exec(ssh_cmd + ssh_stderr)
           end
           if status != 0
             debug output
@@ -306,15 +308,21 @@ module RHC
       ssh_uri = URI.parse(app.ssh_url)
       ssh_executable = check_ssh_executable! options.ssh
 
-      ssh_cmd = "cat '#{filename}' | #{ssh_executable} #{ssh_uri.user}@#{ssh_uri.host} 'restore#{include_git ? ' INCLUDE_GIT' : ''}'"
-      ssh_stderr = " 2>/dev/null"
+     if RHC::Helpers.windows?
+        ssh_cmd = "type '#{filename}' | #{ssh_executable} #{ssh_uri.user}@#{ssh_uri.host} 'restore#{include_git ? ' INCLUDE_GIT' : ''}'"
+      else
+        ssh_cmd = "cat '#{filename}' | #{ssh_executable} #{ssh_uri.user}@#{ssh_uri.host} 'restore#{include_git ? ' INCLUDE_GIT' : ''}'"
+      end
+
+      ssh_stderr = debug? ? '' : ' 2>/dev/null'
       debug ssh_cmd
 
       say "Restoring from snapshot #{filename} to application '#{app.name}' ... "
 
       begin
-        if !RHC::Helpers.windows?
-          status, output = exec(ssh_cmd + (debug? ? '' : ssh_stderr))
+        if !RHC::Helpers.windows? || options.ssh
+          debug "Using user specified SSH: #{ssh_executable}" if options.ssh
+          status, output = exec(ssh_cmd + ssh_stderr)
           if status != 0
             debug output
             raise RHC::SnapshotRestoreException.new "Error in trying to restore snapshot. You can try to restore manually by running:\n#{ssh_cmd}"

--- a/man/express.conf.5
+++ b/man/express.conf.5
@@ -42,6 +42,9 @@ Number of seconds before remote operations will timeout.
 .I default_rhlogin
 The default rhc client tools rhlogin.  Used as the default when the \-l argument is not passed to each of the client tools.
 
+.I ssh
+The ssh executable path to use for operations utilizing ssh. Options included with the path will be used during ssh operations.
+
 .SH "FILES"
 .I <ruby_gem_dir>/gems/rhc\-<version>/conf/express.conf
 .RS

--- a/spec/rhc/commands/tail_spec.rb
+++ b/spec/rhc/commands/tail_spec.rb
@@ -77,5 +77,19 @@ describe RHC::Commands::Tail do
       it { run_output.should =~ /The server does not support operations on individual gears./ }
     end
 
+    context 'succeeds when interrupted using specified ssh executable' do
+      ssh_path = '/usr/bin/ssh'
+
+      before(:each) do
+        base_config { |c, d| d.add 'ssh', ssh_path }
+        stdout = double('file handle')
+        Open3.should_receive(:popen3).with(/#{ssh_path} -t.*/).and_yield(nil, stdout, nil, nil)
+        stdout.should_receive(:gets).and_return("some tail output")
+        subject.class.any_instance.stub(:print).and_raise(Interrupt)
+      end
+
+      it { expect { run }.to raise_error(Interrupt) }
+    end
+
   end
 end


### PR DESCRIPTION
Bug 1177753
https://bugzilla.redhat.com/show_bug.cgi?id=1177753

Previously, a `--ssh` option could be passed to a few subcommands to use a seperate ssh executable other than that found in the default PATH. After this commit, this option is now a global options used in all commands utilizing ssh. A `ssh` option is now available in configuration that allows this global option to be set persistently.

The snapshot-restore, snapshot-save, and tail commands will now use the an ssh executable if specified. If no ssh executable is specified, the Net::SSH implementations will continue to be used.

The port-forward command will not attempt to actually forward ports with a custom ssh executable. This is due to how errors reported from a custom ssh executable are unpredictable. If one or more of the port-forwards fails, the error reported is not predictable enough to script a workaround or helpful error message. If a custom ssh executable is specified when port-forward is called, rhc will use the custom ssh executable to gather the ports and services that will need to be forwarded from the application. It will then use this information to construct a command that the user can run to forward the ports themselves. The command structure assumes that the ssh executable uses the same flags as openSSH.

The scp command will not attempt to use any ssh executable. Instead, a helpful error will be reported with an scp command. The user can use the command to upload/download the file themselves. If the client is on windows, no scp command is provided since we cannot assume that the client has an scp executable available. Instead, a helpful error message will be provided instructing the user to investigate 3rd-party alternatives such as FileZilla and WinSCP.