### PR TITLE
rhc.1 man page: adds scp to list of resources

### DIFF
--- a/man/rhc.1
+++ b/man/rhc.1
@@ -65,6 +65,10 @@ Manage membership on domains
 .B port-forward
 Forward remote ports to the workstation
 .TP
+.PD
+.B scp
+Secure copy to upload or download a file to or from an application
+.TP
 .PD 1
 .B server
 Display information about the status of the service


### PR DESCRIPTION
The scp command was missing from the list of rhc resources in the man page.  This commit adds scp and a short description to the list of resources.