### PR TITLE
rhc.1 man page: adds scp to list of resources

### DIFF
--- a/man/rhc.1
+++ b/man/rhc.1
@@ -66,6 +66,10 @@ Manage membership on domains
 Forward remote ports to the workstation
 .TP
 .PD 1
+.B scp
+Secure copy to upload or download a file to or from an application
+.TP
+.PD 1
 .B server
 Display information about the status of the service
 .TP


### PR DESCRIPTION
The scp command was missing from the list of rhc resources in the man page.  This commit adds scp and a short description to the list of resources.