### PR TITLE
rhc.gemspec: limits cucumber dependency to prevent a ruby 1.9.3 requirement

### DIFF
--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -329,7 +329,7 @@ module RHC
         else
           $terminal.color(item, *args)
         end
-      else 
+      else
         item
       end
     end
@@ -522,7 +522,15 @@ module RHC
 
     # split spaces but preserve sentences between quotes
     def split_path(s, keep_quotes=false)
-      keep_quotes ? s.split(/\s(?=(?:[^"]|"[^"]*")*$)/) : CSV::parse_line(s, :col_sep => ' ')
+      #:nocov:
+      if keep_quotes
+        s.split(/\s(?=(?:[^"]|"[^"]*")*$)/)
+      elsif RUBY_VERSION.to_f < 1.9
+        CSV::parse_line(s, fs = ' ')
+      else #ruby 1.9 or newer
+        CSV::parse_line(s, :col_sep => ' ')
+      end
+      #:nocov:
     end
 
     def discover_windows_executables(&block)

--- a/rhc.gemspec
+++ b/rhc.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency  'rspec',        '>= 2.8.0', '< 2.99'
   s.add_development_dependency  'fakefs',       '>= 0.4', '< 0.6.0'
   s.add_development_dependency  'thor'
-  s.add_development_dependency  'cucumber'
+  s.add_development_dependency  'cucumber',     '<= 1.3.20'
   s.add_development_dependency  'activesupport', '~> 3.0'
 end

--- a/spec/rhc/commands/ssh_spec.rb
+++ b/spec/rhc/commands/ssh_spec.rb
@@ -28,7 +28,7 @@ describe RHC::Commands::Ssh do
       it { expect{ run }.to exit_with_code(0) }
     end
   end
-  
+
   describe 'ssh without command including debugging' do
     let(:arguments) { ['app', 'ssh', 'app1', '--debug'] }
 
@@ -173,18 +173,17 @@ describe RHC::Commands::Ssh do
 
   describe 'app ssh custom ssh with spaces and arguments' do
     let(:arguments) { ['app', 'ssh', 'app1', '--ssh', '"/path/to /ssh" --with_custom_flag'] }
-    context 'when custom ssh does not exist as a path' do
-      before(:each) do
-        @domain = rest_client.add_domain("mockdomain")
-        @domain.add_application("app1", "mock_type")
-        RHC::Commands::Ssh.any_instance.should_not_receive(:has_ssh?)
-        File.should_receive(:exist?).at_least(1).and_return(true)
-        File.should_receive(:executable?).at_least(1).and_return(true)
-        subject.class.any_instance.stub(:discover_git_executable).and_return('git')
-        Kernel.should_receive(:exec).with("/path/to /ssh", '--with_custom_flag', "fakeuuidfortestsapp1@127.0.0.1").once.times.and_return(0)
-      end
-      it { expect { run }.to exit_with_code(0) }
+
+    before(:each) do
+      @domain = rest_client.add_domain("mockdomain")
+      @domain.add_application("app1", "mock_type")
+      RHC::Commands::Ssh.any_instance.should_not_receive(:has_ssh?)
+      File.should_receive(:exist?).at_least(1).and_return(true)
+      File.should_receive(:executable?).at_least(1).and_return(true)
+      subject.class.any_instance.stub(:discover_git_executable).and_return('git')
+      Kernel.should_receive(:exec).with("/path/to /ssh", "--with_custom_flag", "fakeuuidfortestsapp1@127.0.0.1").once.times.and_return(0)
     end
+    it { expect { run }.to exit_with_code(0) }
   end
 
   describe 'ssh tests' do


### PR DESCRIPTION
Updates gemspec to limit cucumber to 2.0.2 or earlier, which in turn limits cucumber's depency of gherkin to gherkin 2.12 or earlier.  Gherkin3 requires ruby 1.9.3 or greater, whereas RHC requires 1.8.7 or later.


[WIP] Testing with CI.