### PR TITLE
gemspec: Restore net-ssh lower bound

### DIFF
--- a/rhc.gemspec
+++ b/rhc.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     sep
   ].join("\n")
 
-  s.add_dependency              'net-ssh',      '<= 2.9.2'
+  s.add_dependency              'net-ssh',      '>= 2.0.11', '<= 2.9.2'
   s.add_dependency              'net-scp',      '>= 1.1.2'
   s.add_dependency              'net-ssh-multi','>= 1.2.0'
   s.add_dependency              'archive-tar-minitar'


### PR DESCRIPTION
Restore the net-ssh '>= 2.0.11' lower bound that commit 0f99298f939ef303485e95aaf41a331b30f51831 deleted.  Without the lower bound, we are seeing the following error from `bundle install`:

```
Bundler could not find compatible versions for gem "net-ssh":
  In Gemfile:
    rhc (>= 0) ruby depends on
      net-ssh (<= 2.9.2) ruby

    rhc (>= 0) ruby depends on
      net-ssh (3.0.1)
```

-

[test]

-

This works for me on Red Hat Enterprise Linux 6, Red Hat Enterprise Linux 7, and Fedora 21.  If necessary, I can test with Windows or other Fedora releases on Monday.