### PR TITLE
Bug 1164699 - Avoid using --summary and --verbose together for `rhc apps`

### DIFF
--- a/lib/rhc/commands/apps.rb
+++ b/lib/rhc/commands/apps.rb
@@ -15,6 +15,7 @@ module RHC::Commands
 
       info "In order to deploy applications, you must create a domain with 'rhc setup' or 'rhc create-domain'." and return 1 if applications.empty? && rest_client.domains.empty?
       info "No applications. Use 'rhc create-app'." and return 1 if applications.nil? || applications.empty?
+      info "You used the -v/--verbose and -s/--summary options together, but they are incompatible." and return 1 if options.summary && options.verbose
 
       if options.summary
         display_app_summary(applications)

--- a/spec/rhc/commands/apps_spec.rb
+++ b/spec/rhc/commands/apps_spec.rb
@@ -32,7 +32,7 @@ describe RHC::Commands::Apps do
           output.should match(/scaled.*\-\-.*php.*Scaling:.*x2 \(minimum/m)
         end
       end
-      
+
       context 'with apps in summary mode' do
         let(:arguments) { ['apps', '--summary' ] }
         before{ domain.add_application('scaled', 'php', true) }
@@ -43,6 +43,14 @@ describe RHC::Commands::Apps do
           output.should match("You have access to 1 application\\.")
           output.should match(/scaled.*https.*/m)
         end
+      end
+
+      context 'with apps in summary and verbose mode' do
+        let(:arguments) { ['apps', '-v', '-s'] }
+        before{ domain.add_application('scaled', 'php', true) }
+
+        it { expect { run }.to exit_with_code(1) }
+        it { run_output.should match("You used the -v/--verbose and -s/--summary options together, but they are incompatible.") }
       end
 
       context 'with one owned app' do


### PR DESCRIPTION
If -s/--sumary and -v/--verbose options are used together in rhc apps,
the verbose option is ignored and only --summary option is executed.

This commmit adds an info output to notify user that both options are
used and advise user to use only one at a time.

Bug 1164699
Link <https://bugzilla.redhat.com/show_bug.cgi?id=1164699>

Signed-off-by: Vu Dinh <vdinh@redhat.com>