### PR TITLE
Bug 1141093 - rhc snapshot save same filename didn't prompt conflict warning

### DIFF
--- a/lib/rhc/commands/snapshot.rb
+++ b/lib/rhc/commands/snapshot.rb
@@ -30,7 +30,10 @@ module RHC::Commands
 
       raise RHC::DeploymentsNotSupportedException.new if options.deployment && !rest_app.supports?("DEPLOY")
 
-      filename = options.filepath ? options.filepath : "#{rest_app.name}.tar.gz"
+      filename = options.filepath || "#{rest_app.name}.tar.gz"
+      if File.exists? filename
+        return 0 unless RHC::Helpers.agree "File #{filename} already exists. Do you want to overwrite this file? (yes|no): "
+      end
 
       save_snapshot(rest_app, filename, options.deployment, options.ssh)
 


### PR DESCRIPTION
The 'rhc snapshot save -f' command overwrites existing file without warning
if user inputs same filename for two different apps.

This commit modifies the rhc snapshow command to verify if the file already
exists and ask user for confirmation before proceeding.

Bug 1141093
Link <https://bugzilla.redhat.com/show_bug.cgi?id=1141093>

Signed-off-by: Vu Dinh <vdinh@redhat.com>