### PR TITLE
Do not redirect stderr to /dev/null on windows

### DIFF
--- a/lib/rhc/commands/tail.rb
+++ b/lib/rhc/commands/tail.rb
@@ -47,8 +47,10 @@ module RHC::Commands
             debug "Running with ruby's ssh implementation: #{ssh_cmd}"
             ssh_ruby(host, uuid, remote_cmd, false, true)
           else
-            ssh_stderr = " 2>/dev/null"
-            ssh_cmd << ssh_stderr unless debug?
+            if !windows?
+              ssh_stderr = " 2>/dev/null"
+              ssh_cmd << ssh_stderr unless debug?
+            end
             debug "Running #{ssh_cmd}"
             Open3.popen3(ssh_cmd) do |stdin, stdout, stderr, thread|
               while line=stdout.gets do


### PR DESCRIPTION
When stderr is redirected to `/dev/null`, no output is seen from `rhc tail` and the command ends immediately. After this change, no redirection will occur when run on windows systems, resolving this issue.

Additionally, the `rhc snapshot-save` and `rhc snapshot-restore` commands were suffering from the same issue. This has been resolved by, again, only adding the stderr redirection to `/dev/null` when not run on windows.

Bug 1177753
https://bugzilla.redhat.com/show_bug.cgi?id=1177753