### PR TITLE
Enable deployment operations to utilize a custom ssh executable

### DIFF
--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -497,7 +497,7 @@ module RHC::Commands
 
       raise RHC::DeploymentsNotSupportedException.new if !rest_app.supports? "DEPLOY"
 
-      deploy_artifact(rest_app, ref, options.hot_deploy, options.force_clean_build)
+      deploy_artifact(rest_app, ref)
 
       0
     end

--- a/lib/rhc/commands/port_forward.rb
+++ b/lib/rhc/commands/port_forward.rb
@@ -99,10 +99,7 @@ module RHC::Commands
         else
           debug "Using #{ssh_executable} to determine forwarding ports."
           ssh_cmd = "#{ssh_executable} #{ssh_uri.user}@#{ssh_uri.host} '#{list_ports_cmd} 2>&1'"
-          status, output = exec(ssh_cmd)
-          if status != 0
-            raise RHC::SSHCommandFailed.new(status, output)
-          end
+          status, output = run_with_system_ssh(ssh_cmd)
         end
 
         output.each_line do |line|

--- a/lib/rhc/deployment_helpers.rb
+++ b/lib/rhc/deployment_helpers.rb
@@ -9,15 +9,15 @@ module RHC
 
     protected
 
-      def deploy_artifact(rest_app, artifact, hot_deploy, force_clean_build)
+      def deploy_artifact(rest_app, artifact)
         is_file = File.file?(artifact)
         is_url = URI::ABS_URI.match(artifact).present?
 
         if rest_app.deployment_type == 'binary'
           if is_file
-            deploy_local_file(rest_app, artifact, hot_deploy, force_clean_build)
+            deploy_local_file(rest_app, artifact, options.hot_deploy, options.force_clean_build)
           elsif is_url
-            deploy_file_from_url(rest_app, artifact, hot_deploy, force_clean_build)
+            deploy_file_from_url(rest_app, artifact, options.hot_deploy, options.force_clean_build)
           else
             paragraph do
               warn "The application '#{rest_app.name}' is configured for binary deployments but the artifact "\
@@ -36,21 +36,28 @@ module RHC
           end
           raise IncompatibleDeploymentTypeException
         else
-          deploy_git_ref(rest_app, artifact, hot_deploy, force_clean_build)
+          deploy_git_ref(rest_app, artifact, options.hot_deploy, options.force_clean_build)
         end
       end
 
       def deploy_git_ref(rest_app, ref, hot_deploy, force_clean_build)
         say "Deployment of git ref '#{ref}' in progress for application #{rest_app.name} ..."
 
+        ssh_executable = check_ssh_executable! options.ssh
+
         ssh_url = URI(rest_app.ssh_url)
         remote_cmd = "gear deploy #{ref}#{hot_deploy ? ' --hot-deploy' : ''}#{force_clean_build ? ' --force-clean-build' : ''}"
+        ssh_cmd = "#{ssh_executable} -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
 
         begin
-          ssh_ruby(ssh_url.host, ssh_url.user, remote_cmd)
+          if options.ssh
+            debug "Running #{ssh_cmd}"
+            run_with_system_ssh(ssh_cmd)
+          else
+            ssh_ruby(ssh_url.host, ssh_url.user, remote_cmd)
+          end
           success "Success"
         rescue
-          ssh_cmd = "ssh -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
           warn "Error deploying git ref. You can try to deploy manually with:\n#{ssh_cmd}"
           raise
         end
@@ -60,14 +67,25 @@ module RHC
         filename = File.expand_path(filename)
         say "Deployment of file '#{filename}' in progress for application #{rest_app.name} ..."
 
+        ssh_executable = check_ssh_executable! options.ssh
+
         ssh_url = URI(rest_app.ssh_url)
         remote_cmd = "oo-binary-deploy#{hot_deploy ? ' --hot-deploy' : ''}#{force_clean_build ? ' --force-clean-build' : ''}"
+        if windows?
+          ssh_cmd = "type #{filename} | #{ssh_executable} -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
+        else
+          ssh_cmd = "cat #{filename} | #{ssh_executable} -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
+        end
 
         begin
-          ssh_send_file_ruby(ssh_url.host, ssh_url.user, remote_cmd, filename)
+          if options.ssh
+            debug "Running #{ssh_cmd}"
+            run_with_system_ssh(ssh_cmd)
+          else
+            ssh_send_file_ruby(ssh_url.host, ssh_url.user, remote_cmd, filename)
+          end
           success "Success"
         rescue
-          ssh_cmd = "ssh -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
           warn "Error deploying local file. You can try to deploy manually with:\n#{ssh_cmd}"
           raise
         end
@@ -76,16 +94,23 @@ module RHC
       def deploy_file_from_url(rest_app, file_url, hot_deploy, force_clean_build)
         say "Deployment of file '#{file_url}' in progress for application #{rest_app.name} ..."
 
+        ssh_executable = check_ssh_executable! options.ssh
+
         ssh_url = URI(rest_app.ssh_url)
         file_url = URI(file_url)
 
         remote_cmd = "oo-binary-deploy#{hot_deploy ? ' --hot-deploy' : ''}#{force_clean_build ? ' --force-clean-build' : ''}"
+        ssh_cmd = "#{ssh_executable} -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
 
         begin
-          ssh_send_url_ruby(ssh_url.host, ssh_url.user, remote_cmd, file_url)
+          if options.ssh
+            debug "Running #{ssh_cmd}"
+            run_with_system_ssh(ssh_cmd)
+          else
+            ssh_send_url_ruby(ssh_url.host, ssh_url.user, remote_cmd, file_url)
+          end
           success "Success"
         rescue
-          ssh_cmd = "ssh -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
           warn "Error deploying file from url. You can try to deploy manually with:\n#{ssh_cmd}"
           raise
         end
@@ -94,14 +119,21 @@ module RHC
       def activate_deployment(rest_app, deployment_id)
         say "Activating deployment '#{deployment_id}' on application #{rest_app.name} ..."
 
+        ssh_executable = check_ssh_executable! options.ssh
+
         ssh_url = URI(rest_app.ssh_url)
         remote_cmd = "gear activate --all #{deployment_id}"
+        ssh_cmd = "#{ssh_executable} -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
 
         begin
-          ssh_ruby(ssh_url.host, ssh_url.user, remote_cmd)
+          if options.ssh
+            debug "Running #{ssh_cmd}"
+            run_with_system_ssh(ssh_cmd)
+          else
+            ssh_ruby(ssh_url.host, ssh_url.user, remote_cmd)
+          end
           success "Success"
         rescue
-          ssh_cmd = "ssh -t #{ssh_url.user}@#{ssh_url.host} '#{remote_cmd}'"
           warn "Error activating deployment. You can try to activate manually with:\n#{ssh_cmd}"
           raise
         end

--- a/spec/rhc/commands/deployment_spec.rb
+++ b/spec/rhc/commands/deployment_spec.rb
@@ -12,252 +12,8 @@ describe RHC::Commands::Deployment do
     user_config
     @rest_app = rest_client.add_domain("mock_domain").add_application(DEPLOYMENT_APP_NAME, 'ruby-1.8.7')
     @rest_app.stub(:ssh_url).and_return("ssh://user@test.domain.com")
-    @targz_filename = File.dirname(__FILE__) + '/' + DEPLOYMENT_APP_NAME + '.tar.gz'
-    FileUtils.cp(File.expand_path('../../assets/targz_sample.tar.gz', __FILE__), @targz_filename)
-    File.chmod 0644, @targz_filename unless File.executable? @targz_filename
-  end
-
-  after do
-    File.delete @targz_filename if File.exist? @targz_filename
-  end
-
-  describe "configure app" do
-    context "manual deployment keeping a history of 10" do
-      let(:arguments) {['app', 'configure', '--app', DEPLOYMENT_APP_NAME, '--no-auto-deploy', '--keep-deployments', '10']}
-      it "should succeed" do
-        expect{ run }.to exit_with_code(0)
-        run_output.should match(/Configuring application '#{DEPLOYMENT_APP_NAME}' .../)
-        run_output.should match(/done/)
-        @rest_app.auto_deploy.should == false
-        @rest_app.keep_deployments.should == 10
-        run_output.should match(/Your application '#{DEPLOYMENT_APP_NAME}' is now configured as listed above/)
-      end
-    end
-
-    context "with no configuration options" do
-      let(:arguments) {['app', 'configure', '--app', DEPLOYMENT_APP_NAME]}
-      it "should display the current configuration" do
-        expect{ run }.to exit_with_code(0)
-        run_output.should_not match(/Configuring application '#{DEPLOYMENT_APP_NAME}' .../)
-        run_output.should_not match(/done/)
-        run_output.should match(/Your application '#{DEPLOYMENT_APP_NAME}' is configured as listed above/)
-      end
-    end
-  end
-
-  describe "deploy" do
-    context "git ref successfully" do
-      before { Net::SSH.should_receive(:start).exactly(3).times.with('test.domain.com', 'user', :compression=>false) }
-      let(:arguments) {['app', 'deploy', 'master', '--app', DEPLOYMENT_APP_NAME]}
-      it "should succeed" do
-        expect{ run }.to exit_with_code(0)
-        run_output.should match(/Deployment of git ref 'master' in progress for application #{DEPLOYMENT_APP_NAME} .../)
-        run_output.should match(/Success/)
-      end
-    end
-
-    context "binary file successfully" do
-      before do
-        @rest_app.stub(:deployment_type).and_return('binary')
-        ssh = double(Net::SSH)
-        session = double(Net::SSH::Connection::Session)
-        channel = double(Net::SSH::Connection::Channel)
-        exit_status = double(Net::SSH::Buffer)
-        exit_status.stub(:read_long).and_return(0)
-        Net::SSH.should_receive(:start).exactly(3).times.with('test.domain.com', 'user', :compression=>false).and_yield(session)
-        session.should_receive(:open_channel).exactly(3).times.and_yield(channel)
-        channel.should_receive(:exec).exactly(3).times.with("oo-binary-deploy").and_yield(nil, nil)
-        channel.should_receive(:on_data).exactly(3).times.and_yield(nil, 'foo')
-        channel.should_receive(:on_extended_data).exactly(3).times.and_yield(nil, nil, '')
-        channel.should_receive(:on_close).exactly(3).times.and_yield(nil)
-        channel.should_receive(:on_request).exactly(3).times.with("exit-status").and_yield(nil, exit_status)
-        lines = ''
-        File.open(@targz_filename, 'rb') do |file|
-          file.chunk(1024) do |chunk|
-            lines << chunk
-          end
-        end
-        channel.should_receive(:send_data).exactly(3).times.with(lines)
-        channel.should_receive(:eof!).exactly(3).times
-        session.should_receive(:loop).exactly(3).times
-      end
-      let(:arguments) {['app', 'deploy', @targz_filename, '--app', DEPLOYMENT_APP_NAME]}
-      it "should succeed" do
-        expect{ run }.to exit_with_code(0)
-        run_output.should match(/Deployment of file '#{@targz_filename}' in progress for application #{DEPLOYMENT_APP_NAME} .../)
-        run_output.should match(/Success/)
-      end
-    end
-
-    [URI('http://foo.com/path/to/file/' + DEPLOYMENT_APP_NAME + '.tar.gz'),
-     URI('https://foo.com/path/to/file/' + DEPLOYMENT_APP_NAME + '.tar.gz')].each do |uri|
-      context "url file successfully" do
-        before do
-        @rest_app.stub(:deployment_type).and_return('binary')
-          ssh = double(Net::SSH)
-          session = double(Net::SSH::Connection::Session)
-          channel = double(Net::SSH::Connection::Channel)
-          exit_status = double(Net::SSH::Buffer)
-          exit_status.stub(:read_long).and_return(0)
-          Net::SSH.should_receive(:start).exactly(3).times.with('test.domain.com', 'user', :compression=>false).and_yield(session)
-          session.should_receive(:open_channel).exactly(3).times.and_yield(channel)
-          channel.should_receive(:exec).exactly(3).times.with("oo-binary-deploy").and_yield(nil, nil)
-          channel.should_receive(:on_data).exactly(3).times.and_yield(nil, 'foo')
-          channel.should_receive(:on_extended_data).exactly(3).times.and_yield(nil, nil, '')
-          channel.should_receive(:on_close).exactly(3).times.and_yield(nil)
-          channel.should_receive(:on_request).exactly(3).times.with("exit-status").and_yield(nil, exit_status)
-          lines = ''
-          File.open(@targz_filename, 'rb') do |file|
-            file.chunk(1024) do |chunk|
-              lines << chunk
-            end
-          end
-          stub_request(:get, uri.to_s).to_return(:status => 200, :body => lines, :headers => {})
-          channel.should_receive(:send_data).exactly(3).times.with(lines)
-          channel.should_receive(:eof!).exactly(3).times
-          session.should_receive(:loop).exactly(3).times
-        end
-        let(:arguments) {['app', 'deploy', uri.to_s, '--app', DEPLOYMENT_APP_NAME]}
-        it "should succeed" do
-          expect{ run }.to exit_with_code(0)
-          run_output.should match(/Deployment of file '#{uri.to_s}' in progress for application #{DEPLOYMENT_APP_NAME} .../)
-          run_output.should match(/Success/)
-        end
-      end
-    end
-
-    context "binary file with corrupted file" do
-      before do
-        @rest_app.stub(:deployment_type).and_return('binary')
-        ssh = double(Net::SSH)
-        session = double(Net::SSH::Connection::Session)
-        channel = double(Net::SSH::Connection::Channel)
-        exit_status = double(Net::SSH::Buffer)
-        exit_status.stub(:read_long).and_return(255)
-        Net::SSH.should_receive(:start).exactly(3).times.with('test.domain.com', 'user', :compression=>false).and_yield(session)
-        session.should_receive(:open_channel).exactly(3).times.and_yield(channel)
-        channel.should_receive(:exec).exactly(3).times.with("oo-binary-deploy").and_yield(nil, nil)
-        channel.should_receive(:on_data).exactly(3).times.and_yield(nil, 'foo')
-        channel.should_receive(:on_extended_data).exactly(3).times.and_yield(nil, nil, 'Invalid file')
-        channel.should_receive(:on_close).exactly(3).times.and_yield(nil)
-        channel.should_receive(:on_request).exactly(3).times.with("exit-status").and_yield(nil, exit_status)
-        lines = ''
-        File.open(@targz_filename, 'rb') do |file|
-          file.chunk(1024) do |chunk|
-            lines << chunk
-          end
-        end
-        channel.should_receive(:send_data).exactly(3).times.with(lines)
-        channel.should_receive(:eof!).exactly(3).times
-        session.should_receive(:loop).exactly(3).times
-      end
-      let(:arguments) {['app', 'deploy', @targz_filename, '--app', DEPLOYMENT_APP_NAME]}
-      it "should not succeed" do
-        expect{ run }.to exit_with_code(133)
-        run_output.should match(/Deployment of file '#{@targz_filename}' in progress for application #{DEPLOYMENT_APP_NAME} .../)
-        run_output.should match(/Invalid file/)
-      end
-    end
-
-    context "fails when deploying git ref" do
-      before (:each) { Net::SSH.should_receive(:start).and_raise(Errno::ECONNREFUSED) }
-      let(:arguments) {['app', 'deploy', 'master', '--app', DEPLOYMENT_APP_NAME]}
-      it "should exit with error" do
-        expect{ run }.to exit_with_code(1)
-      end
-    end
-
-    context "fails when deploying binary file" do
-      before (:each) do
-        @rest_app.stub(:deployment_type).and_return('binary')
-        Net::SSH.should_receive(:start).and_raise(Errno::ECONNREFUSED)
-      end
-      let(:arguments) {['app', 'deploy', @targz_filename, '--app', DEPLOYMENT_APP_NAME]}
-      it "should exit with error" do
-        expect{ run }.to exit_with_code(1)
-      end
-    end
-
-    context "fails when deploying binary file" do
-      before (:each) do
-        @rest_app.stub(:deployment_type).and_return('binary')
-        Net::SSH.should_receive(:start).and_raise(SocketError)
-      end
-      let(:arguments) {['app', 'deploy', @targz_filename, '--app', DEPLOYMENT_APP_NAME]}
-      it "should exit with error" do
-        expect{ run }.to exit_with_code(1)
-      end
-    end
-
-    context "fails when deploying url file" do
-      before (:each) do
-        @rest_app.stub(:deployment_type).and_return('binary')
-        Net::SSH.should_receive(:start).and_raise(Errno::ECONNREFUSED)
-      end
-      let(:arguments) {['app', 'deploy', 'http://foo.com/deploy.tar.gz', '--app', DEPLOYMENT_APP_NAME]}
-      it "should exit with error" do
-        expect{ run }.to exit_with_code(1)
-      end
-    end
-
-    context "fails when deploying url file" do
-      before (:each) do
-        @rest_app.stub(:deployment_type).and_return('binary')
-        Net::SSH.should_receive(:start).and_raise(SocketError)
-      end
-      let(:arguments) {['app', 'deploy', 'http://foo.com/deploy.tar.gz', '--app', DEPLOYMENT_APP_NAME]}
-      it "should exit with error" do
-        expect{ run }.to exit_with_code(1)
-      end
-    end
-
-    context 'when run against an unsupported server' do
-      before {
-        @rest_app.links.delete 'UPDATE'
-        @rest_app.links.delete 'DEPLOY'
-      }
-      let(:arguments) {['app', 'deploy', 'master', '--app', DEPLOYMENT_APP_NAME]}
-      it "should raise not supported exception" do
-        expect{ run }.to exit_with_code(132)
-        run_output.should match(/The server does not support deployments/)
-      end
-    end
-
-    context "ssh authentication failure" do
-      before (:each) { Net::SSH.should_receive(:start).exactly(2).times.and_raise(Net::SSH::AuthenticationFailed) }
-      let(:arguments) {['app', 'deploy', 'master', '--app', DEPLOYMENT_APP_NAME]}
-      it "should exit with error" do
-        expect{ run }.to exit_with_code(1)
-        run_output.should match(/Authentication to server test.domain.com with user user failed/)
-      end
-    end
-
-    context "fails when deploying git reference on an app configured to deployment_type = binary" do
-      before { @rest_app.stub(:deployment_type).and_return('binary') }
-      let(:arguments) {['app', 'deploy', 'master', '--app', DEPLOYMENT_APP_NAME]}
-      it "should exit with error" do
-        expect{ run }.to exit_with_code(133)
-      end
-    end
-
-    context "fails when deploying file on an app configured to deployment_type = git" do
-      before { @rest_app.stub(:deployment_type).and_return('git') }
-      let(:arguments) {['app', 'deploy', @targz_filename, '--app', DEPLOYMENT_APP_NAME]}
-      it "should exit with error" do
-        expect{ run }.to exit_with_code(133)
-      end
-    end
-
-    [URI('http://foo.com/path/to/file/' + DEPLOYMENT_APP_NAME + '.tar.gz'),
-     URI('https://foo.com/path/to/file/' + DEPLOYMENT_APP_NAME + '.tar.gz')].each do |uri|
-      context "fails when deploying url on an app configured to deployment_type = git" do
-        before { @rest_app.stub(:deployment_type).and_return('git') }
-        let(:arguments) {['app', 'deploy', uri.to_s, '--app', DEPLOYMENT_APP_NAME]}
-        it "should exit with error" do
-          expect{ run }.to exit_with_code(133)
-        end
-      end
-    end
+    @instance = RHC::Commands::Deployment.new
+    RHC::Commands::Deployment.stub(:new).and_return(@instance)
   end
 
   describe "activate deployment" do
@@ -265,6 +21,20 @@ describe RHC::Commands::Deployment do
       before { Net::SSH.should_receive(:start).exactly(3).times.with('test.domain.com', 'user', :compression => false) }
       let(:arguments) {['deployment', 'activate', '123456', '--app', DEPLOYMENT_APP_NAME]}
       it "should succeed" do
+        expect{ run }.to exit_with_code(0)
+        run_output.should match(/Activating deployment '123456' on application #{DEPLOYMENT_APP_NAME} .../)
+        run_output.should match(/Success/)
+      end
+    end
+
+    context "activates 123456 with custom ssh executable" do
+      ssh_path = '/usr/bin/ssh'
+      before do
+        @instance.stub(:exec).and_return([0, "success"])
+      end
+      let(:arguments) {['deployment', 'activate', '123456', '--app', DEPLOYMENT_APP_NAME, '--ssh', ssh_path]}
+      it "should succeed" do
+        @instance.should_receive(:run_with_system_ssh).with(/#{ssh_path}/).at_least(:once)
         expect{ run }.to exit_with_code(0)
         run_output.should match(/Activating deployment '123456' on application #{DEPLOYMENT_APP_NAME} .../)
         run_output.should match(/Success/)


### PR DESCRIPTION
Bug 1177753
https://bugzilla.redhat.com/show_bug.cgi?id=1177753

Deploying a git ref, binary file, or binary file url previously only used ruby's implementation of ssh through the `Net::SSH` library. After this change, these deployment operations will honor the `--ssh` global option or `ssh` configuration directive.

Additionally, activating deployments will now also honor a custom ssh executable.

Still writing tests. All other tests are still passing, besides the missed test coverage.