### PR TITLE
Limit Addressable to 2.3.x to ensure compatibility with Ruby 1.8

### DIFF
--- a/rhc.gemspec
+++ b/rhc.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency      'highline',     '~> 1.6.11'
   s.add_runtime_dependency      'httpclient',   '>= 2.4.0', '< 2.7.0'
   s.add_runtime_dependency      'open4'
+  s.add_runtime_dependency      'addressable',  '< 2.4'
   s.add_development_dependency  'rake',         '>= 0.8.7'
   s.add_development_dependency  'webmock',      '< 1.12'
   s.add_development_dependency  'rspec',        '>= 2.8.0', '< 2.99'


### PR DESCRIPTION
With the release of addressable 2.4, ruby-1.8.x is no longer supported. Addressable 2.4 requires at least ruby-1.9.

Ensure that a version of addressable prior to the 2.4 release is used.