### PR TITLE
helpers.rb: remove old ssl output from error message

### DIFF
--- a/lib/rhc/helpers.rb
+++ b/lib/rhc/helpers.rb
@@ -250,7 +250,7 @@ module RHC
     end
 
     def parse_ssl_version(version)
-      OpenSSL::SSL::SSLContext::METHODS.find{ |m| m.to_s.downcase == version.to_s.downcase } or raise OptionParser::InvalidOption.new(nil, "The provided SSL version '#{version}' is not valid. Supported values: #{OpenSSL::SSL::SSLContext::METHODS.map(&:to_s).map(&:downcase).join(', ')}") unless version.nil?
+      OpenSSL::SSL::SSLContext::METHODS.find{ |m| m.to_s.downcase == version.to_s.downcase } or raise OptionParser::InvalidOption.new(nil, "The provided SSL version '#{version}' is not valid. Supported values: #{OpenSSL::SSL::SSLContext::METHODS.map(&:to_s).map(&:downcase).select{|s|!s.include?("sslv")}.join(', ')}") unless version.nil?
     end
 
     #


### PR DESCRIPTION
Bug 1156382
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1156382

Ruby still provides support for sslv3, sslv2, and sslv23 (sslv3 with dropback to
sslv2).  These versions of ssl are not supported with openshift, and shouldn't
be shown as valid options to the user.  The error message for "rhc build show --ssl-version foo" will now remove ssl options from the output to avoid conflicting information to the user.

The current output is this:
```
# rhc domain show --ssl-version foo
invalid option: --ssl-version  The provided SSL version 'foo' is not valid. Supported values: tlsv1, tlsv1_server, tlsv1_client, sslv2, sslv2_server, sslv2_client, sslv3, sslv3_server, sslv3_client, sslv23,
sslv23_server, sslv23_client
```

And the old ssl versions should be removed, looking more like this:
```
# rhc domain show --ssl-version foo
invalid option: --ssl-version  The provided SSL version 'foo' is not valid. Supported values: tlsv1, tlsv1_server, tlsv1_client
```



