### PR TITLE
'rhc app show <app> --gears quota' use 'quota' not 'du'

### DIFF
--- a/lib/rhc/commands/app.rb
+++ b/lib/rhc/commands/app.rb
@@ -425,7 +425,8 @@ module RHC::Commands
         case options.gears
         when 'quota'
           opts = {:as => :gear, :split_cells_on => /\s*\t/, :header => ['Gear', 'Cartridges', 'Used', 'Limit'], :align => [nil, nil, :right, :right]}
-          table_from_gears('echo "$(du --block-size=1 -s 2>/dev/null | cut -f 1)"', groups, opts) do |gear, data, group|
+          # quota 'blocks' are actually kbytes, so have to multiply by 1024, see 'man quota'
+          table_from_gears('echo "$(quota | awk \' NR == 3 { print $2 * 1024 }\')" ', groups, opts) do |gear, data, group|
             [gear['id'], group.cartridges.collect{ |c| c['name'] }.join(' '), (human_size(data.chomp) rescue 'error'), human_size(group.quota)]
           end
         when 'ssh'

--- a/spec/rhc/commands/app_spec.rb
+++ b/spec/rhc/commands/app_spec.rb
@@ -822,7 +822,7 @@ describe RHC::Commands::App do
       before do
         @domain = rest_client.add_domain("mockdomain")
         @domain.add_application("app1", "mock_type", true)
-        expect_multi_ssh('echo "$(du --block-size=1 -s 2>/dev/null | cut -f 1)"', 'fakegearid0@fakesshurl.com' => '1734334', 'fakegearid1@fakesshurl.com' => '1934348')
+        expect_multi_ssh('echo "$(quota | awk \' NR == 3 { print $2 * 1024 }\')" ', 'fakegearid0@fakesshurl.com' => '1734334', 'fakegearid1@fakesshurl.com' => '1934348')
       end
       it { run_output.should match(/Gear.*Cartridges.*Used.*fakegearid0.*1\.7 MB.*1 GB.*fakegearid1.*1\.9 MB/m) }
       it { expect{ run }.to exit_with_code(0) }


### PR DESCRIPTION
Bug 1109935
Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1109935

Users expect 'rhc app show <app> --gears quota' to display output of the system 'quota' cmd.
Currently, the rhc cmd uses 'du -s'.  This PR replaces 'du' with 'quota'