### PR TITLE
update search path for 'ssh.exe'

### DIFF
--- a/lib/rhc/commands/git_clone.rb
+++ b/lib/rhc/commands/git_clone.rb
@@ -23,7 +23,7 @@ module RHC::Commands
 
         0
       else
-        error "You do not have git installed. In order to fully interact with OpenShift you will need to install and configure a git client.#{RHC::Helpers.windows? ? ' We recommend this free application: Git for Windows - a basic git command line and GUI client http://msysgit.github.io/.' : ''}"
+        error "You do not have git installed. In order to fully interact with OpenShift you will need to install and configure a git client.#{RHC::Helpers.windows? ? ' We recommend this free application: Git for Windows - a basic git command line and GUI client https://git-for-windows.github.io/.' : ''}"
         2
       end
     end

--- a/lib/rhc/ssh_helpers.rb
+++ b/lib/rhc/ssh_helpers.rb
@@ -458,12 +458,14 @@ module RHC
 
         #:nocov:
         if RHC::Helpers.windows?
-          # looks for ssh.exe from msysgit or plink.exe from PuTTY, either on path or specific locations
+          # looks for ssh.exe from git-for-windows or plink.exe from PuTTY, either on path or specific locations
           guessing_locations <<
             discover_windows_executables do |base|
-              [
+              from_files = ENV['PATH'].split(File::PATH_SEPARATOR).map {|p| p + File::ALT_SEPARATOR + 'ssh.exe'}
+              from_files + [
                 'ssh.exe',
                 "#{base}\\Git\\bin\\ssh.exe",
+                "#{base}\\Git\\usr\\bin\\ssh.exe",
                 "#{base}\\ssh.exe",
                 'plink.exe',
                 "#{base}\\PuTTY\\plink.exe",
@@ -495,7 +497,7 @@ module RHC
     def check_ssh_executable!(path)
       if not path
         discover_ssh_executable.tap do |ssh_cmd|
-          raise RHC::InvalidSSHExecutableException.new("No system SSH available. Please use the --ssh option to specify the path to your SSH executable, or install SSH.#{windows? ? ' We recommend this free application: Git for Windows - a basic git command line and GUI client http://msysgit.github.io/.' : ''}") unless ssh_cmd or has_ssh?
+          raise RHC::InvalidSSHExecutableException.new("No system SSH available. Please use the --ssh option to specify the path to your SSH executable, or install SSH.#{windows? ? ' We recommend this free application: Git for Windows - a basic git command line and GUI client https://git-for-windows.github.io/.' : ''}") unless ssh_cmd or has_ssh?
         end
       else
         bin_path = split_path(path)[0]

--- a/lib/rhc/wizard.rb
+++ b/lib/rhc/wizard.rb
@@ -631,7 +631,7 @@ In order to fully interact with OpenShift you will need to install and configure
 
 We recommend these free applications:
 
-  * Git for Windows - a basic git command line and GUI client http://msysgit.github.io/
+  * Git for Windows - a basic git command line and GUI client https://git-for-windows.github.io/
   * TortoiseGit - git client that integrates into the file explorer http://code.google.com/p/tortoisegit/
  
 EOF


### PR DESCRIPTION
bz 1294401
bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1294401

'rhc ssh <app>' fails with Windows 10 Home Edition because rhc does
not recognize 'C:\Program Files\Git\usr\bin\ssh.exe' as a possible
location for 'ssh.exe'.  Updated to add this path.  Also, updated the
Git install site recommendation since the current site is obsolete.