### PR TITLE
Fixes net-ssh dependency issues with different ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,13 @@ if Gem::Specification.respond_to?(:find_all_by_name) and not Gem::Specification:
   gem 'psych'
 end
 
-# See https://bugzilla.redhat.com/show_bug.cgi?id=1197301
-gem "net-ssh", "<= 2.9.2"
+# Install older version of net-ssh if using older version of ruby
+# https://bugzilla.redhat.com/show_bug.cgi?id=1288667
+if RUBY_VERSION < '2.0'
+  gem "net-ssh", "<=2.9.2"
+else
+  gem "net-ssh", ">=3.0.0"
+end
 
 # Latest versions of these gems do not support ruby_18
 gem "rake", "< 10.1.2"

--- a/rhc.gemspec
+++ b/rhc.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
     sep
   ].join("\n")
 
-  s.add_dependency              'net-ssh',      '>= 2.0.11', '<= 2.9.2'
   s.add_dependency              'net-scp',      '>= 1.1.2'
   s.add_dependency              'net-ssh-multi','>= 1.2.0'
   s.add_dependency              'archive-tar-minitar'


### PR DESCRIPTION
Bug 1288667
https://bugzilla.redhat.com/show_bug.cgi?id=1288667

Running on ruby-2.0 or greater allows for the use of net-ssh 3.0 or greater.
Using net-ssh 2.9.2 or lower with ruby version 2.2.3 or greater causes major
issues. This should ensure that users with ruby 1.9.3 or less use net-ssh 2.9.2
and users above 1.9.3 should use at least net-ssh 3.0.