### PR TITLE
Limits addressable for ruby 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,11 @@ end
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1197301
 gem "net-ssh", "<= 2.9.2"
 
+# Limit addressable for 1.8.7 due to deprecated support
+if RUBY_VERSION < '1.9'
+  gem "addressable", "<2.4.0"
+end
+
 # Latest versions of these gems do not support ruby_18
 gem "rake", "< 10.1.2"
 gem "i18n", "< 0.7.0"


### PR DESCRIPTION
The addressable gem is a dependency for rhc.  Addressable >=2.4.0 is what is
used now, however it does not support ruby 1.8.7, which was causing it to fail.
This change will limit addressable to <2.4.0 when using ruby 1.8.7.