### PR TITLE
Modifying rhc to focus support on ruby1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,18 @@ if Gem::Specification.respond_to?(:find_all_by_name) and not Gem::Specification:
   gem 'psych'
 end
 
-# See https://bugzilla.redhat.com/show_bug.cgi?id=1197301
-gem "net-ssh", "<= 2.9.2"
+# Limit net-ssh when using older versions of ruby
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1197301 for the 2.9.2 limit
+if RUBY_VERSION < '2.0'
+  gem "net-ssh", "<= 2.9.2"
+else
+  gem "net-ssh", ">= 3.0.0"
+end
+
+# Limits addressable for Ruby 1.8.7
+if RUBY_VERSION < '1.9'
+  gem "addressable", "< 2.4.0"
+end
 
 # Latest versions of these gems do not support ruby_18
 gem "rake", "< 10.1.2"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ comments.  For more information about OpenShift, visit https://openshift.redhat.
 or the OpenShift support page
 https://openshift.redhat.com/support.
 
+RHC from rubygems.org is built on Ruby 1.8.7.  RHC does have conditional 
+dependencies during build time, so it can be built on multiple versions of Ruby.  
+If you are running into any dependency issues when using RHC, please try to 
+build RHC locally using `gem build rhc.gemspec` to use the correct dependencies.
 
 ## Using RHC to create an application
 

--- a/rhc.gemspec
+++ b/rhc.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
     sep
   ].join("\n")
 
-  s.add_dependency              'net-ssh',      '>= 2.0.11', '<= 2.9.2'
   s.add_dependency              'net-scp',      '>= 1.1.2'
   s.add_dependency              'net-ssh-multi','>= 1.2.0'
   s.add_dependency              'archive-tar-minitar'


### PR DESCRIPTION
With Ruby 1.8.7 and 1.9.3 being deprecated, many gems are dropping support for
them.  These dependencies make it impossible for rhc to support both Ruby 1.8.7
and newer Ruby 2.x versions at the same time.  With the upcoming move towards
OpenShift v3 - we will be focusing support on Ruby 1.8.7.  We're going to try to
support as far forward as possible without breaking rhc on Ruby 1.8.7.