### PR TITLE
Update Gemfile dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,4 @@ end
 gem "rake", "< 10.1.2"
 gem "i18n", "< 0.7.0"
 gem "commander", "< 4.3.0"
+gem "json", "< 2.0.0"


### PR DESCRIPTION
The json gem, which is required as a dependency for cucumber, recently released
a new version that is no longer compatible with Ruby 1.x.  This change specifies
a json gem version that will still be compatible with Ruby 1.x while also
meeting cucumber's dependency requirements.