### PR TITLE
Updates dependency limits for addressable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ end
 # Limits addressable for Ruby 1.8.7
 if RUBY_VERSION < '1.9'
   gem "addressable", "< 2.4.0"
+elsif RUBY_VERSION < '2.0'
+  gem "addressable", "< 2.5.0"
 end
 
 # Latest versions of these gems do not support ruby_18


### PR DESCRIPTION
The addressable gem has been updated and the latest version now requires Ruby
2.0.  Added a case to limit addressable when using an older Ruby version.

@miciah This should fix the building issues.